### PR TITLE
Faster 13LoC method + fixes to scripts

### DIFF
--- a/Legion/LegionTokens/FirstClassEntertainment.cs
+++ b/Legion/LegionTokens/FirstClassEntertainment.cs
@@ -11,7 +11,6 @@ public class FirstClassEntertainment
     public CoreBots Core => CoreBots.Instance;
     public CoreLegion Legion = new CoreLegion();
     public CoreAdvanced Adv = new CoreAdvanced();
-    public CoreStory Story = new CoreStory();
     public void ScriptMain(IScriptInterface bot)
     {
         Core.SetOptions();

--- a/Legion/LegionTokens/FirstClassEntertainment.cs
+++ b/Legion/LegionTokens/FirstClassEntertainment.cs
@@ -11,6 +11,7 @@ public class FirstClassEntertainment
     public CoreBots Core => CoreBots.Instance;
     public CoreLegion Legion = new CoreLegion();
     public CoreAdvanced Adv = new CoreAdvanced();
+    public CoreStory Story = new CoreStory();
     public void ScriptMain(IScriptInterface bot)
     {
         Core.SetOptions();

--- a/Other/Classes/ArchMage.cs
+++ b/Other/Classes/ArchMage.cs
@@ -481,7 +481,7 @@ public class Archmage
 
                 case "Vital Exanima":
                     if (Bot.Config.Get<bool>("Armying?"))
-                        Core.HuntMonster("Dage", "Dage", item, isTemp: false);
+                        Core.HuntMonster("Dage", "Dage the Evil", item, isTemp: false);
                     if (!Core.CheckInventory(item))
                         Core.Logger($"{item} Not Found, Can Be Farmed (with an Army) from [Dage] in [Dage]", stopBot: true);
                     break;

--- a/Other/FarmerJoeOutfit.cs
+++ b/Other/FarmerJoeOutfit.cs
@@ -135,7 +135,7 @@ public class FarmerJoeStartingTheAcc
         //step 1 Farming Classes:
         Core.Logger("Farming Classes");
         //LOC.Complete13LOC(true);
-        MDS.MountDoomSkull();
+        MDS.EasyMountDoomSkull();
         Farm.ChaosREP();
         Adv.BuyItem("Confrontation", 891, "Chaos Slayer Berserker", shopItemID: 24359);
         Adv.rankUpClass("Chaos Slayer Berserker");

--- a/Other/FarmerJoeOutfit.cs
+++ b/Other/FarmerJoeOutfit.cs
@@ -34,6 +34,7 @@
 //cs_include Scripts/Story/Tutorial.cs
 //cs_include Scripts/Other/Weapons/DualChainSawKatanas.cs
 //cs_include Scripts/Other\FreeBoostsQuest(10mns).cs
+//cs_include Scripts/Other/MountDoomSkull.cs
 using Skua.Core.Interfaces;
 using Skua.Core.Models.Items;
 using Skua.Core.Models.Quests;
@@ -65,6 +66,7 @@ public class FarmerJoeStartingTheAcc
     public Tutorial Tutorial = new();
     public DualChainSawKatanas DCSK = new();
     public FreeBoosts Boosts = new();
+    public MountDoomSkull MDS = new();
 
     public string OptionsStorage = "FarmerJoePet";
     public bool DontPreconfigure = true;
@@ -132,7 +134,8 @@ public class FarmerJoeStartingTheAcc
         #region Prepare for Lvl100
         //step 1 Farming Classes:
         Core.Logger("Farming Classes");
-        LOC.Complete13LOC(true);
+        //LOC.Complete13LOC(true);
+        MDS.MountDoomSkull();
         Farm.ChaosREP();
         Adv.BuyItem("Confrontation", 891, "Chaos Slayer Berserker", shopItemID: 24359);
         Adv.rankUpClass("Chaos Slayer Berserker");

--- a/Other/MountDoomSkull.cs
+++ b/Other/MountDoomSkull.cs
@@ -2,7 +2,7 @@
 //cs_include Scripts/CoreFarms.cs
 using Skua.Core.Interfaces;
 
-public class DefaultTemplate
+public class MountDoomSkull
 {
     public IScriptInterface Bot => IScriptInterface.Instance;
     public CoreBots Core => CoreBots.Instance;
@@ -14,14 +14,14 @@ public class DefaultTemplate
         //To skip clearing Lord of Chaos story, useful when starting account to faster farm for others
         Core.SetOptions();
 
-        MountDoomSkull();
+        EasyMountDoomSkull();
 
         Core.SetOptions(false);
     }
 
-    public void MountDoomSkull()
+    public void EasyMountDoomSkull()
     {
-        Core.Join(mountdoomskull);
+        Core.Join("mountdoomskull");
         //13Loc
         Core.Logger("Doing 13 Lord of Chaos");
         Core.SendPackets("%xt%zm%tryQuestComplete%60014%3578%-1%false%wvz%");
@@ -48,11 +48,7 @@ public class DefaultTemplate
         Core.SendPackets("%xt%zm%setAchievement%937075%ia1%22%1%");
         Core.SendPackets("%xt%zm%tryQuestComplete%937075%3766%-1%false%wvz%");
 
-        //New finale
-        Core.Join(newfinale);
-        Core.Logger("Donezo!")
-
-        
+        Core.Join("newfinale");
 
     }
 }

--- a/Other/MountDoomSkull.cs
+++ b/Other/MountDoomSkull.cs
@@ -1,0 +1,58 @@
+//cs_include Scripts/CoreBots.cs
+//cs_include Scripts/CoreFarms.cs
+using Skua.Core.Interfaces;
+
+public class DefaultTemplate
+{
+    public IScriptInterface Bot => IScriptInterface.Instance;
+    public CoreBots Core => CoreBots.Instance;
+    public CoreFarms Farm = new();
+
+    public void ScriptMain(IScriptInterface bot)
+    {
+        //Credit to Arts
+        //To skip clearing Lord of Chaos story, useful when starting account to faster farm for others
+        Core.SetOptions();
+
+        MountDoomSkull();
+
+        Core.SetOptions(false);
+    }
+
+    public void MountDoomSkull()
+    {
+        Core.Join(mountdoomskull);
+        //13Loc
+        Core.Logger("Doing 13 Lord of Chaos");
+        Core.SendPackets("%xt%zm%tryQuestComplete%60014%3578%-1%false%wvz%");
+        Core.SendPackets("%xt%zm%tryQuestComplete%937075%3579%-1%false%wvz%");
+        Core.SendPackets("%xt%zm%tryQuestComplete%937075%3580%-1%false%wvz%");
+        Core.SendPackets("%xt%zm%tryQuestComplete%937075%3581%-1%false%wvz%");
+        Core.SendPackets("%xt%zm%tryQuestComplete%937075%3582%-1%false%wvz%");
+        Core.SendPackets("%xt%zm%tryQuestComplete%937075%3583%-1%false%wvz%");
+        Core.SendPackets("%xt%zm%tryQuestComplete%937075%3584%-1%false%wvz%");
+        Core.SendPackets("%xt%zm%tryQuestComplete%937075%3585%-1%false%wvz%");
+        Core.SendPackets("%xt%zm%tryQuestComplete%937075%3586%-1%false%wvz%");
+        Core.SendPackets("%xt%zm%tryQuestComplete%937075%3587%-1%false%wvz%");
+        Core.SendPackets("%xt%zm%tryQuestComplete%937075%3588%-1%false%wvz%");
+        Core.SendPackets("%xt%zm%tryQuestComplete%937075%3589%-1%false%wvz%");
+        Core.SendPackets("%xt%zm%tryQuestComplete%937075%3590%-1%false%wvz%");
+        Core.SendPackets("%xt%zm%tryQuestComplete%937075%3591%-1%false%wvz%");
+        
+        //Drakath Defeated
+        Core.Logger("Doing drakath defeated");
+        Core.Jump("NPC2", "Left");
+        Core.EnsureAccept(3765);
+        Core.SendPackets("%xt%zm%getMapItem%937075%2726%");
+        Core.EnsureComplete(3675);
+        Core.SendPackets("%xt%zm%setAchievement%937075%ia1%22%1%");
+        Core.SendPackets("%xt%zm%tryQuestComplete%937075%3766%-1%false%wvz%");
+
+        //New finale
+        Core.Join(newfinale);
+        Core.Logger("Donezo!")
+
+        
+
+    }
+}

--- a/Story/LordsofChaos/Core13LoC.cs
+++ b/Story/LordsofChaos/Core13LoC.cs
@@ -1923,7 +1923,7 @@ public class Core13LoC
         }
 
         //Pure Chaos
-        if (!Story.QuestProgression(3185) || (Core.isCompletedBefore(3188) ? false : !Core.CheckInventory("nchaorrupted Sample")) )
+        if (!Story.QuestProgression(3185) || (Core.isCompletedBefore(3188) ? false : !Core.CheckInventory("Unchaorrupted Sample")) )
         {
             Core.AddDrop("Unchaorrupted Sample");
             Core.EnsureAccept(3185);


### PR DESCRIPTION
Added an alternative method for 13 LoC, you can skip the entire story just to save time.

Added it to FarmerJoe, so the bot can farm for chaos rep instead to buy Chaos Slayer, this boat does  'Drakath Faced' which is the requirement for the shop.

*and fixes because im dumb lol