### PR TITLE
Added voucher option for Archmage

### DIFF
--- a/Other/Classes/ArchMage.cs
+++ b/Other/Classes/ArchMage.cs
@@ -440,7 +440,7 @@ public class Archmage
         {
             Core.EnsureAccept(8912);
             if (Bot.Config.Get<bool>("Voucher"))
-                Adv.BuyItem("alchemyacademy", 395, "Dragon Runestone", 3, 8845);
+                Adv.BuyItem("alchemyacademy", 395, "Dragon Runestone", 30, 8845);
             else 
                 Adv.BuyItem("alchemyacademy", 395, "Dragon Runestone", 30, 8844);
             Adv.BuyItem("darkthronehub", 1308, "Exalted Paladin Seal");

--- a/Other/Classes/ArchMage.cs
+++ b/Other/Classes/ArchMage.cs
@@ -38,7 +38,8 @@ public class Archmage
         CoreBots.Instance.SkipOptions,
         new Option<bool>("Lumina Elementi", "Lumina Elementi", "Todo the last quest or not, for the 51% wep(takes awhileand will require aditional boss items.) [On by default]", true),
         new Option<bool>("Cosmetics", "Get Cosmetics", "Gets the cosmetic rewards (redoes quests if you don't have them, disable to just get Archmage and the weapon) [On by default]", true),
-        new Option<bool>("Armying?", "Armying?", "use when running on 4 accounts at once only, will probably get out of sync.) [Off by default]", false)
+        new Option<bool>("Armying?", "Armying?", "use when running on 4 accounts at once only, will probably get out of sync.) [Off by default]", false),
+        new Option<bool>("Voucher", "Dragon stone", "Buy dragon stone with 500k vouchers? [Off by default]", false)
     };
 
     private string[] RequiredItems = { "Archmage", "Providence", "Mystic Scribing Kit", "Prismatic Ether", "Arcane Locus", "Unbound Tome", "Book of Magus", "Book of Fire", "Book of Ice", "Book of Aether", "Book of Arcana", "Arcane Sigil", "Archmage" };
@@ -438,7 +439,10 @@ public class Archmage
         while (!Bot.ShouldExit && !Core.CheckInventory("Unbound Tome", quant))
         {
             Core.EnsureAccept(8912);
-            Adv.BuyItem("alchemyacademy", 395, "Dragon Runestone", 30, 8844);
+            if (Bot.Config.Get<bool>("Voucher"))
+                Adv.BuyItem("alchemyacademy", 395, "Dragon Runestone", 3, 8845);
+            else 
+                Adv.BuyItem("alchemyacademy", 395, "Dragon Runestone", 30, 8844);
             Adv.BuyItem("darkthronehub", 1308, "Exalted Paladin Seal");
             Adv.BuyItem("shadowfall", 89, "Forsaken Doom Seal");
             Core.EnsureComplete(8912);


### PR DESCRIPTION
Bot now can purchase Dragon Runestones  with either 500k or 100k voucher.

Requested by DD#1750