### PR TITLE
Aggro for HuntMonster

### DIFF
--- a/CoreBots.cs
+++ b/CoreBots.cs
@@ -1885,7 +1885,7 @@ public class CoreBots
             {
                 // If was previously aggro when untoggled
                 // Set aggro back and flip last aggro
-                Logger("Flipping aggro to False");
+                //Logger("Flipping aggro to False");
                 last_aggro_status = false;
                 Bot.Options.AggroMonsters = true;
             }
@@ -1900,7 +1900,7 @@ public class CoreBots
             {
                 // If currently aggro, set last aggro to true
                 // and flip current aggro status
-                Logger("Flipping aggro to False");
+                //Logger("Flipping aggro to False");
                 last_aggro_status = true;
                 Bot.Options.AggroMonsters = false;
             }

--- a/CoreBots.cs
+++ b/CoreBots.cs
@@ -1458,7 +1458,9 @@ public class CoreBots
         if (!isTemp && item != null)
             AddDrop(item);
 
+        ToggleAggro(false);
         Join(map, publicRoom: publicRoom);
+        ToggleAggro(true);
         if (item == null)
         {
             if (log)
@@ -1501,8 +1503,10 @@ public class CoreBots
             return;
         if (!isTemp && item != null)
             AddDrop(item);
-        Join(map, publicRoom: publicRoom);
 
+        ToggleAggro(false);
+        Join(map, publicRoom: publicRoom);
+        ToggleAggro(true);
         Monster? monster = Bot.Monsters.MapMonsters?.Find(m => m.MapID == monsterMapID);
         if (monster == null)
         {

--- a/Evil/NSoD/CoreNSOD.cs
+++ b/Evil/NSoD/CoreNSOD.cs
@@ -165,10 +165,11 @@ public class CoreNSOD
         if (!Core.CheckInventory("Necromancer", toInv: false) && !Core.CheckInventory("Creature Shard", toInv: false))
             Core.AddDrop("Creature Shard");
         Core.Logger($"Gathering {quant} Void Aura's with Non-Mem/Non-SDKA Method");
+        Core.ConfigureAggro();
 
-        Core.RegisterQuests(4432);
         while (!Bot.ShouldExit && !Core.CheckInventory("Void Aura", quant))
         {
+            Core.EnsureAccept(4432);
             Core.HuntMonster("timespace", "Astral Ephemerite", "Astral Ephemerite Essence", Essencequant, false, log: false);
             Core.HuntMonster("citadel", "Belrot the Fiend", "Belrot the Fiend Essence", Essencequant, false, publicRoom: true, log: false);
             Core.KillMonster("greenguardwest", "BKWest15", "Down", "Black Knight", "Black Knight Essence", Essencequant, false, publicRoom: true, log: false);
@@ -179,11 +180,11 @@ public class CoreNSOD
             Core.HuntMonster("timevoid", "Unending Avatar", "Unending Avatar Essence", Essencequant, false, publicRoom: true, log: false);
             Core.HuntMonster("dragonchallenge", "Void Dragon", "Void Dragon Essence", Essencequant, false, publicRoom: true, log: false);
             Core.KillMonster("maul", "r3", "Down", "Creature Creation", "Creature Creation Essence", Essencequant, false, publicRoom: true, log: false);
-
+            Core.EnsureCompleteMulti(4432);
             Bot.Wait.ForPickup("Void Aura");
             Core.Logger($"{Bot.Inventory.GetQuantity("Void Aura")}/{quant})");
         }
-        Core.CancelRegisteredQuests();
+        Core.ConfigureAggro(false);
     }
 
     #endregion


### PR DESCRIPTION
Was running RVA bot with aggro, it’s using huntmonster, so when the bot tries to jump after farming Item 1 to Map 2 for Item 2, it’s getting stuck because aggro is still on. Adding toggle aggro to the function seems like fixed it, I have been running it for 4 hours.

Example of benefits of Aggro
RVA hunts Dai Tengu that has 15 room limit, aggro useful for this or user will missout every kills

ToggleBoost is so spammy, I think this logger is supposed to be for dev only?