### PR TITLE
MergeShops: buy single item & dotnet formatting

### DIFF
--- a/Army/Quests/ArmyUniqueQuarry.cs
+++ b/Army/Quests/ArmyUniqueQuarry.cs
@@ -130,8 +130,8 @@ public class ArmyUniqueQuarry
                 Army.AggroMonStart("chaoswar");
                 Army.DivideOnCells("r2");
             }
-            else 
-            {                
+            else
+            {
                 Army.AggroMonCells("r1", "r2");
                 Army.AggroMonStart("chaoswar");
                 Army.DivideOnCells("r1", "r2");

--- a/Army/Various/ArmyBloodMoonToken.cs
+++ b/Army/Various/ArmyBloodMoonToken.cs
@@ -9,7 +9,7 @@ public class ArmyBloodMoonToken
     private CoreBots Core => CoreBots.Instance;
     private CoreArmyLite Army = new();
     private static CoreArmyLite sArmy = new();
-    
+
     public string OptionsStorage = "ArmyBloodMoonToken";
     public bool DontPreconfigure = true;
     public List<IOption> Options = new List<IOption>()

--- a/Army/Various/ArmyDarkonErrands.cs
+++ b/Army/Various/ArmyDarkonErrands.cs
@@ -48,7 +48,7 @@ public class ArmyDarkonErrands
 
         else if (Method.ToString() == "Second_Errands")
             GetItem("doomvault", new[] { "Binky" }, 7325, "Darkon's Receipt", quant);
-            
+
         else if (Method.ToString() == "First_Errands_Strong_Team")
         {
             Core.EquipClass(ClassType.Farm);

--- a/Army/Various/ArmyLegionFealty2.cs
+++ b/Army/Various/ArmyLegionFealty2.cs
@@ -62,7 +62,7 @@ public class ArmyLegionFealty2
         Core.EquipClass(ClassType.Farm);
         Core.AddDrop("Conquest Wreath");
         Core.Logger("Selling Cohort Conquered's to sync accs (hopefully)");
-        
+
         foreach (string item in CoHortList)
             Core.SellItem(item, all: true);
 
@@ -130,7 +130,7 @@ public class ArmyLegionFealty2
             return;
         if (Bot.Map.Name == "doomvault")
         {
-            Army.AggroMonMIDs(1,2,3,6,7,8);
+            Army.AggroMonMIDs(1, 2, 3, 6, 7, 8);
             Army.AggroMonStart("doomvault");
             Army.DivideOnCells("r1", "r3");
         }

--- a/Army/Various/ArmyLegionToken.cs
+++ b/Army/Various/ArmyLegionToken.cs
@@ -52,11 +52,11 @@ public class ArmyLegionToken
     public void Setup(Method Method, int quant = 25000)
     {
         Legion.JoinLegion();
-        
+
         Core.EquipClass(ClassType.Farm);
         if (Method.ToString() == "Dreadrock")
             Core.BuyItem("underworld", 216, "Undead Champion");
-            GetItem("dreadrock", new[] { "Fallen Hero", "Hollow Wraith", "Legion Sentinel", "Shadowknight", "Void Mercenary" }, 4849, "Legion Token", quant);
+        GetItem("dreadrock", new[] { "Fallen Hero", "Hollow Wraith", "Legion Sentinel", "Shadowknight", "Void Mercenary" }, 4849, "Legion Token", quant);
         if (Method.ToString() == "Shogun_Paragon_Pet")
             GetItem("fotia", new[] { "Fotia Elemental", "Fotia Spirit" }, 5755, "Legion Token", quant);
         else

--- a/Army/Various/ArmyLightCasterFull.cs
+++ b/Army/Various/ArmyLightCasterFull.cs
@@ -62,9 +62,9 @@ public class ArmyLightCaster
     public void LightCaster()
     {
         Core.EquipClass(ClassType.Farm);
-        Core.AddDrop(38153,31058,30266,31019,31028);
+        Core.AddDrop(38153, 31058, 30266, 31019, 31028);
 
-        while (!Bot.ShouldExit && !Core.CheckInventory(new[] {38153, 31058}))
+        while (!Bot.ShouldExit && !Core.CheckInventory(new[] { 38153, 31058 }))
         {
             Core.EnsureAccept(4510);
             Core.EnsureAccept(4511);
@@ -107,7 +107,7 @@ public class ArmyLightCaster
         Core.Join(map);
         WaitCheck();
         Core.EnsureAccept(questID);
-        
+
         foreach (string monster in monsters)
             Army.SmartAggroMonStart(map, monsters);
 

--- a/Army/Various/ArmyMirrorRealmToken.cs
+++ b/Army/Various/ArmyMirrorRealmToken.cs
@@ -9,7 +9,7 @@ public class ArmyMirrorRealmToken
     private CoreBots Core => CoreBots.Instance;
     private CoreArmyLite Army = new();
     private static CoreArmyLite sArmy = new();
-    
+
     public string OptionsStorage = "ArmyMirrorRealmToken";
     public bool DontPreconfigure = true;
     public List<IOption> Options = new List<IOption>()
@@ -54,10 +54,10 @@ public class ArmyMirrorRealmToken
             Core.RegisterQuests(3188);
             Army.SmartAggroMonStart("mirrorportal", "Chaos Harpy");
         }
-        
+
         while (!Bot.ShouldExit && (!Core.CheckInventory("Mirror Realm Token", 300)))
-                Bot.Combat.Attack("*");
-            Army.AggroMonStop(true);
+            Bot.Combat.Attack("*");
+        Army.AggroMonStop(true);
     }
 
     public enum Method

--- a/Army/Various/ArmyPrismaticSeams.cs
+++ b/Army/Various/ArmyPrismaticSeams.cs
@@ -36,7 +36,7 @@ public class ArmyPrimaticSeams
         {
             SoW.CompleteCoreSoW();
         }
-        
+
         ArmyPS();
 
         Core.SetOptions(false);

--- a/Army/Various/ArmySpiritOrb.cs
+++ b/Army/Various/ArmySpiritOrb.cs
@@ -49,13 +49,13 @@ public class ArmySpiritOrb
 
         Core.AddDrop(Loot);
         Core.EquipClass(ClassType.Farm);
-		Core.RegisterQuests(2082, 2083);
+        Core.RegisterQuests(2082, 2083);
         Core.Logger($"Farming for {quant} bone dust");
-		Army.SmartAggroMonStart("battleunderb", "Skeleton Warrior", "Skeleton Fighter", "Undead Champion");
+        Army.SmartAggroMonStart("battleunderb", "Skeleton Warrior", "Skeleton Fighter", "Undead Champion");
         while (!Bot.ShouldExit && !Core.CheckInventory("Spirit Orb", quant))
             Bot.Combat.Attack("*");
         Army.AggroMonStop(true);
-		Core.CancelRegisteredQuests();
+        Core.CancelRegisteredQuests();
     }
 
     private string[] Loot = { "Bone Dust", "Undead Essence", "Undead Energy", "Spirit Orb" };

--- a/Chaos/ChaosAvengerPreReqs.cs
+++ b/Chaos/ChaosAvengerPreReqs.cs
@@ -99,7 +99,7 @@ public class ChaosAvengerClass
 
             //Vath's Chaotic Dragonlord Armor
             Core.KillVath("Vath's Chaotic Dragonlord Armor");
-            
+
             //Chaos Shogun Armor
             Core.HuntMonster("kitsune", "Kitsune", "Chaos Shogun Armor", isTemp: false, publicRoom: true);
 

--- a/CoreAdvanced.cs
+++ b/CoreAdvanced.cs
@@ -1280,7 +1280,7 @@ public class CoreAdvanced
                         }
                         break;
                     case WeaponSpecial.Lacerate:
-                        if (!uLaceratey())
+                        if (!uLacerate())
                             Fail();
                         break;
                     case WeaponSpecial.Smite:
@@ -1303,7 +1303,7 @@ public class CoreAdvanced
                             Fail();
                         break;
                     case WeaponSpecial.Acheron:
-                        if (!uArchon())
+                        if (!uAcheron())
                             Fail();
                         break;
                     default:
@@ -1453,7 +1453,7 @@ public class CoreAdvanced
     private int getEnhPatternID(InventoryItem item) => item == null ? 0 : Bot.Flash.GetGameObject<int>($"world.invTree.{item.ID}.EnhPatternID");
 
     private bool uForgeWeapon() => Core.isCompletedBefore(8738);
-    private bool uLaceratey() => Core.isCompletedBefore(8739);
+    private bool uLacerate() => Core.isCompletedBefore(8739);
     private bool uSmite() => Core.isCompletedBefore(8740);
     private bool uValiance() => Core.isCompletedBefore(8741);
     private bool uArcanasConcerto() => Core.isCompletedBefore(8742);
@@ -1462,7 +1462,7 @@ public class CoreAdvanced
     private bool uAvarice() => Core.isCompletedBefore(8745);
     private bool uForgeCape() => Core.isCompletedBefore(8758);
     private bool uElysium() => Core.isCompletedBefore(8821);
-    private bool uArchon() => Core.isCompletedBefore(8820);
+    private bool uAcheron() => Core.isCompletedBefore(8820);
     private bool uPenitence() => Core.isCompletedBefore(8822);
     private bool uLament() => Core.isCompletedBefore(8823);
     private bool uVim() => Core.isCompletedBefore(8824);
@@ -1512,12 +1512,6 @@ public class CoreAdvanced
             case "dark metal necro":
             case "great thief":
             case "legion doomknight":
-            case "void highlord":
-            case "chaos slayer":
-            case "chaos slayer berserker":
-            case "chaos slayer cleric":
-            case "chaos slayer mystic":
-            case "chaos slayer thief":
                 if (!uForgeCape())
                     goto default;
 
@@ -1528,7 +1522,6 @@ public class CoreAdvanced
             #endregion
 
             #region Forge - Lucky - Smite
-            case "necrotic chronomancer":
             case "Draconic Chronomancer":
                 if (!uSmite() || !uForgeCape())
                     goto default;
@@ -1569,7 +1562,6 @@ public class CoreAdvanced
             case "legendary elemental warrior":
             case "ultra elemental warrior":
             case "chaos avenger":
-            case "yami no ronin":
                 if (!uForgeCape())
                     goto default;
 
@@ -1580,8 +1572,6 @@ public class CoreAdvanced
             #endregion
 
             #region Wizard - Forge - Spiral Carve
-            case "legion revenant":
-            case "legion revenant (ioda)":
             case "lightcaster":
                 if (!uForgeCape())
                     goto default;
@@ -1603,37 +1593,119 @@ public class CoreAdvanced
                 break;
             #endregion
 
-            #region Wizard - Forge - Health Vamp
-            case "shaman":
-                if (!uForgeCape())
+            #region Wizard - Vainglory - Valiance - Pneuma
+            case "archmage":
+            case "darklord":
+                if (!uVainglory() || !uValiance() || !uPneuma())
                     goto default;
 
                 type = EnhancementType.Wizard;
-                cSpecial = CapeSpecial.Forge;
-                wSpecial = WeaponSpecial.Health_Vamp;
+                cSpecial = CapeSpecial.Vainglory;
+                wSpecial = WeaponSpecial.Valiance;
+                hSpecial = HelmSpecial.Pneuma;
                 break;
             #endregion
 
-            #region Healer - Forge - Health Vamp
+            #region Wizard - Penitence - Acheron - Pneuma
+            case "master of moglins":
+            case "dark master of moglins":
+                if (!uPenitence() || !uAcheron() || !uPneuma())
+                    goto default;
+
+                type = EnhancementType.Wizard;
+                cSpecial = CapeSpecial.Penitence;
+                wSpecial = WeaponSpecial.Acheron;
+                hSpecial = HelmSpecial.Pneuma;
+                break;
+            #endregion
+
+            #region Wizard - Avarice - Valiance - Pneuma
+            case "legion revenant":
+            case "legion revenant (ioda)":
+                if (!uAvarice() || !uValiance() || !uPneuma())
+                    goto default;
+
+                type = EnhancementType.Wizard;
+                cSpecial = CapeSpecial.Avarice;
+                wSpecial = WeaponSpecial.Valiance;
+                hSpecial = HelmSpecial.Pneuma;
+                break;
+            #endregion
+
+            #region Wizard - Avarice - Elysium - Pneuma
+            case "shaman":
+            case "vampire lord":
+            case "enchanted vampire lord":
+            case "royal vampire lord":
+                if (!uAvarice() || !uElysium() || !uPneuma())
+                    goto default;
+
+                type = EnhancementType.Wizard;
+                cSpecial = CapeSpecial.Avarice;
+                wSpecial = WeaponSpecial.Elysium;
+                hSpecial = HelmSpecial.Pneuma;
+                break;
+            #endregion
+
+            #region Wizard - Avarice - Acheron - Pneuma
+            case "blaze binder":
+                if (!uAvarice() || !uAcheron() || !uPneuma())
+                    goto default;
+
+                type = EnhancementType.Wizard;
+                cSpecial = CapeSpecial.Avarice;
+                wSpecial = WeaponSpecial.Acheron;
+                hSpecial = HelmSpecial.Pneuma;
+                break;
+            #endregion
+
+            #region Wizard - Lament - Elysium - Pneuma
+            case "royal battlemage":
+                if (!uLament() || !uElysium() || !uPneuma())
+                    goto default;
+
+                type = EnhancementType.Wizard;
+                cSpecial = CapeSpecial.Lament;
+                wSpecial = WeaponSpecial.Elysium;
+                hSpecial = HelmSpecial.Pneuma;
+                break;
+            #endregion
+
+            #region Wizard - Lament - Valiance - Pneuma
+            case "scarlet sorceress":
+                if (!uLament() || !uValiance() || !uPneuma())
+                    goto default;
+
+                type = EnhancementType.Wizard;
+                cSpecial = CapeSpecial.Lament;
+                wSpecial = WeaponSpecial.Valiance;
+                hSpecial = HelmSpecial.Pneuma;
+                break;
+            #endregion
+
+            #region Healer - Avarice - Elysium - Pneuma
             case "dragon of time":
-                if (!uForgeCape())
+                if (!uAvarice() || !uElysium() || !uPneuma())
                     goto default;
 
                 type = EnhancementType.Healer;
-                cSpecial = CapeSpecial.Forge;
-                wSpecial = WeaponSpecial.Health_Vamp;
+                cSpecial = CapeSpecial.Avarice;
+                wSpecial = WeaponSpecial.Elysium;
+                hSpecial = HelmSpecial.Pneuma;
                 break;
             #endregion
 
-            #region Lucky - Vainglory - Valiance
-            case "archmage":
+            #region Lucky - Vainglory - Valiance - Anima
             case "archfiend":
-                if (!uVainglory() || !uValiance())
+            case "eternal inversionist":
+            case "dragonlord":
+                if (!uVainglory() || !uValiance() || !uAnima())
                     goto default;
 
                 type = EnhancementType.Lucky;
                 cSpecial = CapeSpecial.Vainglory;
                 wSpecial = WeaponSpecial.Valiance;
+                hSpecial = HelmSpecial.Anima;
                 break;
             #endregion
 
@@ -1648,9 +1720,78 @@ public class CoreAdvanced
                 wSpecial = WeaponSpecial.Valiance;
                 hSpecial = HelmSpecial.Vim;
                 break;
+            #endregion
+
+            #region Lucky - Vainglory - Lacerate - Vim
+            case "yami no ronin":
+                if (!uVainglory() || !uLacerate() || !uVim())
+                    goto default;
+
+                type = EnhancementType.Lucky;
+                cSpecial = CapeSpecial.Vainglory;
+                wSpecial = WeaponSpecial.Lacerate;
+                hSpecial = HelmSpecial.Vim;
+                break;
+            #endregion
+
+            #region Lucky - Vainglory - Valiance - Anima
+            case "nechronomancer":
+            case "necrotic chronomancer":
+                if (!uVainglory() || !uArcanasConcerto() || !uAnima())
+                    goto default;
+
+                type = EnhancementType.Lucky;
+                cSpecial = CapeSpecial.Vainglory;
+                wSpecial = WeaponSpecial.Valiance;
+                hSpecial = HelmSpecial.Anima;
+                break;
+            #endregion
+
+            #region Lucky - Lament - Elysium - Pneuma
+            case "abyssal angel":
+            case "abyssal angel's shadow":
+                if (!uLament() || !uElysium() || !uPneuma())
+                    goto default;
+
+                type = EnhancementType.Lucky;
+                cSpecial = CapeSpecial.Lament;
+                wSpecial = WeaponSpecial.Elysium;
+                hSpecial = HelmSpecial.Pneuma;
+                break;
+            #endregion
+
+            #region Lucky - Lament - Valiance - Vim
+            case "void highlord":
+            case "void highlord (ioda)":
+                if (!uLament() || !uValiance() || !uVim())
+                    goto default;
+
+                type = EnhancementType.Lucky;
+                cSpecial = CapeSpecial.Lament;
+                wSpecial = WeaponSpecial.Valiance;
+                hSpecial = HelmSpecial.Vim;
+                break;
+            #endregion
+
+            #region Lucky - Avarice - Elysium - Anima
+            case "flame dragon warrior":
+            case "chaos slayer":
+            case "chaos slayer berserker":
+            case "chaos slayer cleric":
+            case "chaos slayer mystic":
+            case "chaos slayer thief":
+                if (!uAvarice() || !uElysium() || !uAnima())
+                    goto default;
+
+                type = EnhancementType.Lucky;
+                cSpecial = CapeSpecial.Avarice;
+                wSpecial = WeaponSpecial.Elysium;
+                hSpecial = HelmSpecial.Anima;
+                break;
+            #endregion
 
             #endregion
-            #endregion
+
             #region Awe Enhancement Library
             default:
                 switch (SelectedClass.Name.ToLower())
@@ -1846,14 +1987,14 @@ public class CoreAdvanced
                     case "barber":
                     case "classic dragonlord":
                     case "dragonslayer":
-                    case "enchanted vampire lord":
                     case "enforcer":
                     case "flame dragon warrior":
-                    case "royal vampire lord":
                     case "rustbucket":
                     case "sentinel":
                     case "vampire":
                     case "vampire lord":
+                    case "enchanted vampire lord":
+                    case "royal vampire lord":
                         type = EnhancementType.Lucky;
                         wSpecial = WeaponSpecial.Health_Vamp;
                         break;
@@ -1867,7 +2008,6 @@ public class CoreAdvanced
                     case "blaze binder":
                     case "blood sorceress":
                     case "dark battlemage":
-                    case "dark master of moglins":
                     case "dragon knight":
                     case "firelord summoner":
                     case "grim necromancer":
@@ -1877,6 +2017,7 @@ public class CoreAdvanced
                     case "infinity knight":
                     case "interstellar knight":
                     case "master of moglins":
+                    case "dark master of moglins":
                     case "mystical dark caster":
                     case "northlands monk":
                     case "royal battlemage":

--- a/Dailies/0AllDailies.cs
+++ b/Dailies/0AllDailies.cs
@@ -65,7 +65,7 @@ public class FarmAllDailys
         Daily.BeastMasterChallenge();
         Daily.FungiforaFunGuy();
         Daily.MineCrafting(new[] { "Aluminum", "Barium", "Gold", "Iron", "Copper", "Silver", "Platinum" }, 10, ToBank: true);
-        Daily.HardCoreMetals(new [] { "Arsenic", "Beryllium", "Chromium", "Palladium", "Rhodium", "Rhodium", "Thorium", "Mercury"}, 10, ToBank: true);
+        Daily.HardCoreMetals(new[] { "Arsenic", "Beryllium", "Chromium", "Palladium", "Rhodium", "Rhodium", "Thorium", "Mercury" }, 10, ToBank: true);
         Daily.CryptoToken();
         Daily.GoldenInquisitor();
 

--- a/Darkon/MergeShops/AstraviaCastleMerge.cs
+++ b/Darkon/MergeShops/AstraviaCastleMerge.cs
@@ -36,10 +36,10 @@ public class AstraviaCastleMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("astraviacastle", 2043, findIngredients);
+        Adv.StartBuyAllMerge("astraviacastle", 2043, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Darkon/MergeShops/AstraviaJudgementMerge.cs
+++ b/Darkon/MergeShops/AstraviaJudgementMerge.cs
@@ -34,10 +34,10 @@ public class AstraviaJudgeMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("astraviajudge", 2065, findIngredients);
+        Adv.StartBuyAllMerge("astraviajudge", 2065, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Darkon/MergeShops/AstraviaMerge.cs
+++ b/Darkon/MergeShops/AstraviaMerge.cs
@@ -32,10 +32,10 @@ public class AstraviaMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("astravia", 1987, findIngredients);
+        Adv.StartBuyAllMerge("astravia", 1987, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Darkon/MergeShops/AstraviaPastMerge.cs
+++ b/Darkon/MergeShops/AstraviaPastMerge.cs
@@ -35,10 +35,10 @@ public class AstraviaPastMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("astraviapast", 2126, findIngredients);
+        Adv.StartBuyAllMerge("astraviapast", 2126, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Darkon/MergeShops/EridaniMerge.cs
+++ b/Darkon/MergeShops/EridaniMerge.cs
@@ -32,10 +32,10 @@ public class EridaniMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("eridani", 1912, findIngredients);
+        Adv.StartBuyAllMerge("eridani", 1912, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Darkon/MergeShops/EridaniPastMerge.cs
+++ b/Darkon/MergeShops/EridaniPastMerge.cs
@@ -32,10 +32,10 @@ public class EridaniPastMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("eridanipast", 2112, findIngredients);
+        Adv.StartBuyAllMerge("eridanipast", 2112, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Darkon/MergeShops/FirstObservatoryMerge.cs
+++ b/Darkon/MergeShops/FirstObservatoryMerge.cs
@@ -34,10 +34,10 @@ public class FirstObservatoryMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("firstobservatory", 2130, findIngredients);
+        Adv.StartBuyAllMerge("firstobservatory", 2130, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Darkon/MergeShops/GardenMerge.cs
+++ b/Darkon/MergeShops/GardenMerge.cs
@@ -32,10 +32,10 @@ public class GardenMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("garden", 1831, findIngredients);
+        Adv.StartBuyAllMerge("garden", 1831, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Darkon/MergeShops/GenesisGardenMerge.cs
+++ b/Darkon/MergeShops/GenesisGardenMerge.cs
@@ -34,10 +34,10 @@ public class GenesisGardenMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("genesisgarden", 2136, findIngredients);
+        Adv.StartBuyAllMerge("genesisgarden", 2136, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Darkon/MergeShops/TheWorldHouseMerge.cs
+++ b/Darkon/MergeShops/TheWorldHouseMerge.cs
@@ -32,10 +32,10 @@ public class TheWorldHouseMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("theworld", 2144, findIngredients);
+        Adv.StartBuyAllMerge("theworld", 2144, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Darkon/MergeShops/TheWorldMerge.cs
+++ b/Darkon/MergeShops/TheWorldMerge.cs
@@ -32,10 +32,10 @@ public class TheWorldMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("theworld", 2141, findIngredients);
+        Adv.StartBuyAllMerge("theworld", 2141, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Evil/GravelynDoomFire.cs
+++ b/Evil/GravelynDoomFire.cs
@@ -67,7 +67,7 @@ public class GravelynDoomFire
             Core.EnsureComplete(5461);
             Bot.Wait.ForPickup("Gravelyn's DoomFire Token");
         }
-        
+
         Core.BuyItem("darkthronehub", 1307, "DOOMFire OF Gravelyn");
         Core.BuyItem("darkthronehub", 1307, "Horned DOOMFire Helm");
         Core.ToBank(ShopItems);

--- a/Farm/REP/BrethwrenREP.cs
+++ b/Farm/REP/BrethwrenREP.cs
@@ -16,7 +16,7 @@ public class BrethwrenREPFarm
         Core.SetOptions();
 
         //Farm.UseBoost(ChangeToBoostID, Skua.Core.Models.Items.BoostType.Reputation, false);
-        
+
         HarvestDay.BirdsWithHarms();
 
         Farm.BrethwrenREP();

--- a/Good/GearOfAwe/ArmorOfAwe.cs
+++ b/Good/GearOfAwe/ArmorOfAwe.cs
@@ -49,7 +49,7 @@ public class ArmorOfAwe
         }
         else
             Awe.GetAweRelic("Pauldron", 4160, 15, 15, "gravestrike", "Ultra Akriloth");
-            
+
         Awe.GetAweRelic("Breastplate", 4163, 10, 10, "aqlesson", "Carnax");
         Awe.GetAweRelic("Vambrace", 4166, 15, 15, "bloodtitan", "Ultra Blood Titan");
         Awe.GetAweRelic("Gauntlet", 4169, 25, 5, "alteonbattle", "Ultra Alteon");

--- a/Good/GearOfAwe/CoreAwe.cs
+++ b/Good/GearOfAwe/CoreAwe.cs
@@ -22,7 +22,7 @@ public class CoreAwe
             return;
 
         Core.AddDrop($"{Item} Fragment");
-        
+
         if (Bot.Flash.GetGameObject<int>("world.myAvatar.objData.intAQ") > 0)
         {
             Farm.BladeofAweREP(5, false);

--- a/Good/SilverExaltedPaladin.cs
+++ b/Good/SilverExaltedPaladin.cs
@@ -45,26 +45,26 @@ public class SEP
             // The First Scroll
             Story.KillQuest(7581, "ectocave", "Ichor Dracolich", AutoCompleteQuest: false);
             Core.EnsureCompleteChoose(7581);
-            Core.ToBank(new string[]{"Silver Exalted Helmet", "Silver Exalted Visor"});
+            Core.ToBank(new string[] { "Silver Exalted Helmet", "Silver Exalted Visor" });
 
             // The Second Scroll
             Story.KillQuest(7582, "frozenruins", "Frostdeep Dweller", AutoCompleteQuest: false);
             Core.EnsureCompleteChoose(7582);
-            Core.ToBank(new string[]{"Silver Exalted Winged Helm", "Silver Exalted Winged Visor"});
+            Core.ToBank(new string[] { "Silver Exalted Winged Helm", "Silver Exalted Winged Visor" });
 
             // The Third Scroll
             Story.KillQuest(7583, "thirdspell", "Great Solar Elemental", GetReward: false);
             Core.ToBank("Silver Exalted Haloed Wings");
-           
+
             // The Fourth Scroll
             Story.KillQuest(7584, "table", "Roach", AutoCompleteQuest: false);
             Core.EnsureCompleteChoose(7584);
-            Core.ToBank(new string[]{"Silver Exalted Paladin Spear", "Silver Exalted Paladin Poleaxe", "Silver Exalted Spears of Light"});
+            Core.ToBank(new string[] { "Silver Exalted Paladin Spear", "Silver Exalted Paladin Poleaxe", "Silver Exalted Spears of Light" });
 
             // The Fifth Scroll
             Story.KillQuest(7585, "dracocon", "Singer", AutoCompleteQuest: false);
             Core.EnsureCompleteChoose(7585);
-            Core.ToBank(new string[]{"Silver Exalted Paladin Blade", "Silver Exalted Paladin Axe"});
+            Core.ToBank(new string[] { "Silver Exalted Paladin Blade", "Silver Exalted Paladin Axe" });
         }
         Core.EnsureAccept(7586);
         Core.HuntMonster("warhorc", "General Drox", "Paladin Armor Found");

--- a/Hollowborn/MergeShops/HBChallengeMerge.cs
+++ b/Hollowborn/MergeShops/HBChallengeMerge.cs
@@ -31,10 +31,10 @@ public class HBChallengeMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("hbchallenge", 1887, findIngredients);
+        Adv.StartBuyAllMerge("hbchallenge", 1887, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Hollowborn/MergeShops/HBJudgementMerge.cs
+++ b/Hollowborn/MergeShops/HBJudgementMerge.cs
@@ -31,10 +31,10 @@ public class HBJudgementMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("hbchallenge", 2075, findIngredients);
+        Adv.StartBuyAllMerge("hbchallenge", 2075, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Hollowborn/MergeShops/HollowbornLabMerge.cs
+++ b/Hollowborn/MergeShops/HollowbornLabMerge.cs
@@ -22,7 +22,7 @@ public class HollowbornLabMerge
 
     public void ScriptMain(IScriptInterface Bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Hollowborn Residue "});
+        Core.BankingBlackList.AddRange(new[] { "Hollowborn Residue " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -30,10 +30,10 @@ public class HollowbornLabMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("hbchallenge", 2191, findIngredients);
+        Adv.StartBuyAllMerge("hbchallenge", 2191, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Legion/Various/UndeadLegionMerge.cs
+++ b/Legion/Various/UndeadLegionMerge.cs
@@ -52,10 +52,10 @@ public class UndeadLegionMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("underworld", 238, findIngredients);
+        Adv.StartBuyAllMerge("underworld", 238, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Legion/Various/VulcarsMerge.cs
+++ b/Legion/Various/VulcarsMerge.cs
@@ -42,10 +42,10 @@ public class VulcarsMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("underworld", 1985, findIngredients);
+        Adv.StartBuyAllMerge("underworld", 1985, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()
@@ -87,7 +87,7 @@ public class VulcarsMerge
                         Core.EnsureAccept(7992);
                         Core.HuntMonster("dagefortress", "Grrrberus", "Grrberus' Flame");
                         SSand.SoulSand(3);
-                        Core.EnsureCompleteChoose(7992, new[] {req.Name});
+                        Core.EnsureCompleteChoose(7992, new[] { req.Name });
                     }
                     break;
 

--- a/Nation/MergeShops/FiendishLoreMasterMerge.cs
+++ b/Nation/MergeShops/FiendishLoreMasterMerge.cs
@@ -34,10 +34,10 @@ public class FiendishLoreMasterMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("tercessuinotlim", 2103, findIngredients);
+        Adv.StartBuyAllMerge("tercessuinotlim", 2103, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Nation/MergeShops/FiendshardMerge.cs
+++ b/Nation/MergeShops/FiendshardMerge.cs
@@ -35,10 +35,10 @@ public class FiendshardMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("fiendshard", 1965, findIngredients);
+        Adv.StartBuyAllMerge("fiendshard", 1965, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Nation/MergeShops/NulgathDiamondMerge.cs
+++ b/Nation/MergeShops/NulgathDiamondMerge.cs
@@ -39,10 +39,10 @@ public class NulgathDiamondMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("evilwarnul", 456, findIngredients);
+        Adv.StartBuyAllMerge("evilwarnul", 456, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Nation/OblivionBlade(RareandNot)/OblivionNulgath.cs
+++ b/Nation/OblivionBlade(RareandNot)/OblivionNulgath.cs
@@ -26,10 +26,10 @@ public class OblivionNulgath
     {
         Core.SetOptions();
 
-        COBoN.OblivionNulgath(Bot.Config.Get<string >("Reward"), Bot.Config.Get<int>("Quanity"));
+        COBoN.OblivionNulgath(Bot.Config.Get<string>("Reward"), Bot.Config.Get<int>("Quanity"));
 
         Core.SetOptions(false);
-    }  
+    }
 
     private enum OblivionNulgathRewards
     {

--- a/Nation/TimeIsMoney.cs
+++ b/Nation/TimeIsMoney.cs
@@ -36,13 +36,13 @@ public class TimeIsMoney
                 {
                     //Time is Money 6185
                     Core.EnsureAccept(6185);
-                    
+
                     Core.HuntMonster("Mobius", "Slugfit", "Slugfit Horn", 5);
                     Core.HuntMonster("Mobius", "Fire Imp", "Imp Flame", 3);
                     Core.HuntMonster("bamboo", "Tanuki", "Tanuki Ears", 3);
                     Core.HuntMonster("greenguardwest", "Big Bad Boar", "Wereboar Tusk", 2);
                     Core.HuntMonster("junkyard", "Onibaba", "Onibaba Nails", 5);
-                    
+
                     Core.EnsureComplete(6185);
                 }
         }

--- a/Nation/Various/DemandingApprovalFromNulgath[Member].cs
+++ b/Nation/Various/DemandingApprovalFromNulgath[Member].cs
@@ -10,7 +10,7 @@ public class DemandingApprovalFromNulgath
     public CoreBots Core => CoreBots.Instance;
     public CoreFarms Farm = new();
     public CoreNation Nation = new();
-    
+
 
 
     public void ScriptMain(IScriptInterface bot)

--- a/Nation/Various/GoldenHanzoVoid.cs
+++ b/Nation/Various/GoldenHanzoVoid.cs
@@ -32,7 +32,7 @@ public class GoldenHanzoVoid
         Nation.TheAssistant("Dark Crystal Shard", 15);
         Nation.FarmDiamondofNulgath(50);
         Nation.FarmVoucher(false);
-        
+
         Core.Join("evilwarnul");
         Bot.Shops.Load(456);
         List<ShopItem> shopdata = Bot.Shops.Items;

--- a/Other/0CurrentDailyGifts.cs
+++ b/Other/0CurrentDailyGifts.cs
@@ -110,7 +110,7 @@ public class CurrentDailyGifts
 
             GetGift(AvailableUntil(9, 12), "ebiltakeover", "Ebil Jack Sprat", "Pink POSE! Pitchfork", "Pitchfork of Shadows");
             GetGift(AvailableUntil(9, 12), "hbchallenge", "Module 005", "Module 005 Chibi Pet");
-            GetGift(AvailableUntil(9, 12), "ebiltakeover", "Ebil Red Dragon", "Darkened Adherent Faceplate", "Darken", "Darken Helm", "Prisma Guard", "Prisma Cracked Orb", "Prisma Plunger" ,"Prisma Shoe-Chucks");
+            GetGift(AvailableUntil(9, 12), "ebiltakeover", "Ebil Red Dragon", "Darkened Adherent Faceplate", "Darken", "Darken Helm", "Prisma Guard", "Prisma Cracked Orb", "Prisma Plunger", "Prisma Shoe-Chucks");
             GetGift(AvailableUntil(9, 12), "blackfridaywar", "Deal Bot 2.0", "Rose Phoenix Sword", "Obsidian Phoenix Sword");
             GetGift(AvailableUntil(9, 12), "dreammaster", "Calico Cobby", "Cute Calico Cobby Pet");
 
@@ -125,7 +125,7 @@ public class CurrentDailyGifts
             // GetGift(AvailableUntil(31, 12), "ultrafrostfang", "Ultra Frost Fang", "Antisam's Frost Dragon"); /Release: 15/12/22
             // GetGift(AvailableUntil(31, 12), "snowview", "Acrtic Fox", "Acrtic Fox Pet + Guards"); /Release: 17/12/22
             // GetGift(AvailableUntil(31, 12), "deerhunt", "Zweinichtirsch", "Spirit of Frostval"); /Release: 18/12/22
-            
+
             #endregion
 
             //GetGift(AvailableUntil(1, 1), "map", "monster", "");

--- a/Other/0CurrentDailyGifts.cs
+++ b/Other/0CurrentDailyGifts.cs
@@ -123,8 +123,8 @@ public class CurrentDailyGifts
             GetGift(AvailableUntil(31, 12), "deerhunt", "Deer?", "Little Reindeer Morph", "Reind'AWWW Moglin");
             GetGift(AvailableUntil(31, 12), "yulecat", "Kitty Yu Yule", "Beleen's Festive Frostval Outfit", "Beleen's Festive Hero Hat + Locks", "Beleen's Festive Hero Hat + Hair");
             GetGift(AvailableUntil(31, 12), "ultrafrostfang", "Ultra Frost Fang", "Baby Frost Dragon");
-            // GetGift(AvailableUntil(31, 12), "snowview", "Acrtic Fox", "Acrtic Fox Pet + Guards"); /Release: 17/12/22
-            // GetGift(AvailableUntil(31, 12), "deerhunt", "Zweinichtirsch", "Spirit of Frostval"); /Release: 18/12/22
+            GetGift(AvailableUntil(31, 12), "snowview", "Arctic Fox", "Arctic Fox Guard", "Arctic Fox Guard At Rest", "Arctic Fox Pet");
+            GetGift(AvailableUntil(31, 12), "deerhunt", "Zweinichthirsch", "Spirit Of Frostval", "Frostval Holly + Candle");
 
             #endregion
 

--- a/Other/1%drops/1%Capes.cs
+++ b/Other/1%drops/1%Capes.cs
@@ -51,7 +51,7 @@ public class LowDRCapes
         {
             Core.HuntMonster("finalbattle", "Drakath", "Chaotic Champion Wings", isTemp: false);
         }
-        
+
         if (Bot.Config.Get<Capes>("Capes") == Capes.Wings_Of_Destruction || Bot.Config.Get<Capes>("Capes") == Capes.All && !Core.CheckInventory("Wings Of Destruction"))
         {
             Core.HuntMonster("infernalspire", "Malxas", "Wings Of Destruction", isTemp: false);

--- a/Other/1%drops/1%Helmets.cs
+++ b/Other/1%drops/1%Helmets.cs
@@ -34,7 +34,7 @@ public class LowDRHelmets
             Core.Logger($"\"None\" Selected, Stopping.");
             return;
         }
-        
+
         Core.FarmingLogger($"{Bot.Config.Get<Helmets>("Helmets").ToString()}", 1);
 
         if (Bot.Config.Get<Helmets>("Helmets") == Helmets.Sekts_Mummys_Hat || Bot.Config.Get<Helmets>("Helmets") == Helmets.All && !Core.CheckInventory("Sekt's Mummy's Hat"))

--- a/Other/1%drops/1%Pets.cs
+++ b/Other/1%drops/1%Pets.cs
@@ -34,14 +34,14 @@ public class LowDRPets
             Core.Logger($"\"None\" Selected, Stopping.");
             return;
         }
-        
+
         Core.FarmingLogger($"{Bot.Config.Get<Pets>("Pets").ToString()}", 1);
 
         if (Bot.Config.Get<Pets>("Pets") == Pets.Akriloth_Pet || Bot.Config.Get<Pets>("Pets") == Pets.All && !Core.CheckInventory("Akriloth Pet"))
         {
             Core.HuntMonster("gravestrike", "Ultra Akriloth", "Akriloth Pet", isTemp: false);
         }
- 
+
         // if (Bot.Config.Get<Pets>("Pets") == Pets.Insert || Bot.Config.Get<Pets>("Pets") == Pets.All && !Core.CheckInventory("Insert"))
         // {
         //     Core.HuntMonster("Map", "Mob", "Item", isTemp: false);

--- a/Other/1%drops/1%Weapons.cs
+++ b/Other/1%drops/1%Weapons.cs
@@ -35,57 +35,57 @@ public class LowDRWeapons
             return;
         }
 
-        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Adas_Overcharged_Scythe || Bot.Config.Get<Weapons>("Weapons") == Weapons.All  && !Core.CheckInventory("Ada's Overcharged Scythe"))
+        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Adas_Overcharged_Scythe || Bot.Config.Get<Weapons>("Weapons") == Weapons.All && !Core.CheckInventory("Ada's Overcharged Scythe"))
         {
             Core.HuntMonster("laken", "Ada", "Ada's Overcharged Scythe", isTemp: false);
         }
 
-        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Amethyst_Pickaxe || Bot.Config.Get<Weapons>("Weapons") == Weapons.All  && !Core.CheckInventory("Amethyst Pickaxe"))
+        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Amethyst_Pickaxe || Bot.Config.Get<Weapons>("Weapons") == Weapons.All && !Core.CheckInventory("Amethyst Pickaxe"))
         {
             Core.HuntMonster("djinn", "Tibicenas", "Amethyst Pickaxe", isTemp: false);
         }
 
-        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Ancient_Frying_Pan || Bot.Config.Get<Weapons>("Weapons") == Weapons.All  && !Core.CheckInventory("Ancient Frying Pan"))
+        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Ancient_Frying_Pan || Bot.Config.Get<Weapons>("Weapons") == Weapons.All && !Core.CheckInventory("Ancient Frying Pan"))
         {
             Core.HuntMonster("timevoid", "Unending Avatar", "Ancient Frying Pan", isTemp: false);
         }
 
-        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Blood_of_the_Void_Daggers || Bot.Config.Get<Weapons>("Weapons") == Weapons.All  && !Core.CheckInventory("Blood of the Void Daggers"))
+        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Blood_of_the_Void_Daggers || Bot.Config.Get<Weapons>("Weapons") == Weapons.All && !Core.CheckInventory("Blood of the Void Daggers"))
         {
             Core.HuntMonster("voidbattle", "Jir'abin Challenge", "Blood of the Void Daggers", isTemp: false);
         }
 
-        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Blood_of_the_Void_Blade || Bot.Config.Get<Weapons>("Weapons") == Weapons.All  && !Core.CheckInventory("Blood of the Void Blade"))
+        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Blood_of_the_Void_Blade || Bot.Config.Get<Weapons>("Weapons") == Weapons.All && !Core.CheckInventory("Blood of the Void Blade"))
         {
             Core.HuntMonster("voidbattle", "Jir'abin Challenge", "Blood of the Void Blade", isTemp: false);
         }
 
-        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Purified_Void_Blade || Bot.Config.Get<Weapons>("Weapons") == Weapons.All  && !Core.CheckInventory("Purified Void Blade"))
+        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Purified_Void_Blade || Bot.Config.Get<Weapons>("Weapons") == Weapons.All && !Core.CheckInventory("Purified Void Blade"))
         {
             Core.HuntMonster("voidbattle", "Jir'abin Challenge", "Purified Void Blade", isTemp: false);
         }
 
-        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Purified_Void_Daggers || Bot.Config.Get<Weapons>("Weapons") == Weapons.All  && !Core.CheckInventory("Purified Void Daggers"))
+        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Purified_Void_Daggers || Bot.Config.Get<Weapons>("Weapons") == Weapons.All && !Core.CheckInventory("Purified Void Daggers"))
         {
             Core.HuntMonster("voidbattle", "Jir'abin Challenge", "Purified Void Daggers", isTemp: false);
         }
 
-        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Burning_Blade || Bot.Config.Get<Weapons>("Weapons") == Weapons.All  && !Core.CheckInventory(31058))
+        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Burning_Blade || Bot.Config.Get<Weapons>("Weapons") == Weapons.All && !Core.CheckInventory(31058))
         {
             Core.HuntMonster("lostruinswar", "Diabolical Warlord", "Burning Blade");
         }
 
-        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Deaths_Bright_Blade || Bot.Config.Get<Weapons>("Weapons") == Weapons.All  && !Core.CheckInventory("Death's Bright Blade"))
+        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Deaths_Bright_Blade || Bot.Config.Get<Weapons>("Weapons") == Weapons.All && !Core.CheckInventory("Death's Bright Blade"))
         {
             Core.HuntMonster("tercessuinotlim", "Death's Head", "Death's Bright Blade", isTemp: false);
         }
 
-        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Deaths_Scythe || Bot.Config.Get<Weapons>("Weapons") == Weapons.All  && !Core.CheckInventory(25117))
+        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Deaths_Scythe || Bot.Config.Get<Weapons>("Weapons") == Weapons.All && !Core.CheckInventory(25117))
         {
             Core.HuntMonster("shadowattack", "Death", "Death's Scythe", isTemp: false);
         }
 
-        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Bone_Claws_of_Turmoil || Bot.Config.Get<Weapons>("Weapons") == Weapons.All  && !Core.CheckInventory("Bone Claws of Turmoil"))
+        if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Bone_Claws_of_Turmoil || Bot.Config.Get<Weapons>("Weapons") == Weapons.All && !Core.CheckInventory("Bone Claws of Turmoil"))
         {
             Core.HuntMonster("cloister", "Acornment", "Bone Claws of Turmoil", isTemp: false);
         }
@@ -124,12 +124,12 @@ public class LowDRWeapons
         {
             Core.HuntMonster("stonewooddeep", "Sir Kut", "Feral DoomBlade", isTemp: false);
         }
-        
+
         if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Ruby_Pickaxe || Bot.Config.Get<Weapons>("Weapons") == Weapons.All && !Core.CheckInventory("Ruby Pickaxe"))
         {
             Core.HuntMonster("banished", "Desterrat Moya", "Ruby Pickaxe", isTemp: false);
         }
-        
+
         if (Bot.Config.Get<Weapons>("Weapons") == Weapons.Duel_Swords_of_Vindication || Bot.Config.Get<Weapons>("Weapons") == Weapons.All && !Core.CheckInventory("Duel Swords of Vindication"))
         {
             Core.HuntMonster("xancave", "Shurpu Ring Guardian", "Duel Swords of Vindication", isTemp: false);

--- a/Other/Armor/FiendofLight.cs
+++ b/Other/Armor/FiendofLight.cs
@@ -35,7 +35,7 @@ public class FiendofLight
         CoreSS.SepulchuresRise();
 
         if (!Bot.Config.Get<bool>("SelectReward"))
-            ForeachSelect(6408); 
+            ForeachSelect(6408);
         else OptionsSelect(Bot.Config.Get<RewardsSelection>("RewardSelect"), 6408);
 
         Core.SetOptions(false);

--- a/Other/Armor/FireChampionsArmor.cs
+++ b/Other/Armor/FireChampionsArmor.cs
@@ -48,9 +48,9 @@ public class FireChampionsArmor
 
         if (!Core.CheckInventory(582))
             Core.BuyItem("lair", 38, "Dragonslayer");
-            
+
         Adv.rankUpClass("Dragonslayer");
-        
+
         Farm.Gold(1000000);
         WFE.WarfuryEmblemFarm(30);
         DSG.EnchantedScaleandClaw(30, 0);

--- a/Other/Badges/6thBirthdaySavior.cs
+++ b/Other/Badges/6thBirthdaySavior.cs
@@ -29,7 +29,7 @@ public class BirthdaySavior
 
         Core.Logger($"Doing Artixpointe story for {badge} badge");
         AP.OmniArtifact();
-        
+
     }
 
     private string badge = "6th Birthday Savior";

--- a/Other/Badges/BattleConVIP.cs
+++ b/Other/Badges/BattleConVIP.cs
@@ -28,7 +28,7 @@ public class BattleConVIP
 
         Core.Logger($"Doing UnderGroundLab story for {badge} badge");
         UGL.partofundergroundlabb();
-        
+
     }
 
     private string badge = "BattleCon VIP";

--- a/Other/Badges/CelestialChampion.cs
+++ b/Other/Badges/CelestialChampion.cs
@@ -32,7 +32,7 @@ public class CelestialArenaChampion
         CA.Arena1to10();
         CA.Arena11to20();
         CA.Arena21to29();
-        
+
     }
 
     private string badge = "Celestial Champion";

--- a/Other/Badges/ConZombieSlayer.cs
+++ b/Other/Badges/ConZombieSlayer.cs
@@ -32,7 +32,7 @@ public class ConZombieSlayer
 
         //I Guess We DO Need Steenkin' Badges 3135
         Story.KillQuest(3135, "vendorbooths", "Ravin' Skelly");
-        
+
         //Con Kit 3136
         if (!Story.QuestProgression(3136))
         {
@@ -42,7 +42,7 @@ public class ConZombieSlayer
             Core.HuntMonster("battlecon", "Cosplay Zombie", "Hoopy Frood brand Towel", log: false);
             Core.HuntMonster("battlecon", "Cosplay Zombie", "Event Schedule", log: false);
             Core.HuntMonster("battlecon", "Cosplay Zombie", "Xtra-Strength Energy Potion", log: false);
-            Core.HuntMonster("battlecon", "Cosplay Zombie", "Anti-Con Rot Sanitation Device", log: false);            
+            Core.HuntMonster("battlecon", "Cosplay Zombie", "Anti-Con Rot Sanitation Device", log: false);
             Core.EnsureComplete(3136);
         }
 

--- a/Other/Badges/DesolichFreed.cs
+++ b/Other/Badges/DesolichFreed.cs
@@ -24,7 +24,7 @@ public class DesolichFreed
     {
         if (!Core.IsMember)
             return;
-        
+
         if (Core.HasWebBadge("Desoloth Freed"))
         {
             Core.Logger($"Already have the Desoloth Freed badge");

--- a/Other/Badges/GoldenLaurel.cs
+++ b/Other/Badges/GoldenLaurel.cs
@@ -28,7 +28,7 @@ public class GoldenLaurel
 
         Core.Logger($"Doing Golden Arena story for {badge} badge");
         GA.StoryLine();
-        
+
     }
 
     private string badge = "Golden Laurel";

--- a/Other/Badges/HordeZombieSLAYER.cs
+++ b/Other/Badges/HordeZombieSLAYER.cs
@@ -25,7 +25,7 @@ public class HordeZombieSLAYER
         }
 
         Core.Logger($"Doing quest for {badge} badge");
-        
+
         Core.EquipClass(ClassType.Farm);
 
         Core.EnsureAccept(8670);

--- a/Other/Badges/JusticeSquad.cs
+++ b/Other/Badges/JusticeSquad.cs
@@ -26,7 +26,7 @@ public class JusticeSquadBadge
         Core.Logger($"Doing a quest for the {badge}");
         Core.AddDrop("Enchanted Justice Blade");
         Core.EnsureAccept(5722);
-        Core.HuntMonster("battleontown", "Zard", "Quill Pen", isTemp:true, log:false);
+        Core.HuntMonster("battleontown", "Zard", "Quill Pen", isTemp: true, log: false);
         Core.EnsureComplete(5722);
 
 

--- a/Other/Badges/LordOfTheWeddingRing.cs
+++ b/Other/Badges/LordOfTheWeddingRing.cs
@@ -17,7 +17,7 @@ public class LordOfTheWeddingRing
 
         Core.SetOptions(false);
     }
-    
+
     public void Badge()
     {
         if (Core.HasWebBadge(badge))
@@ -28,7 +28,7 @@ public class LordOfTheWeddingRing
 
         Core.Logger($"Doing Artix Wedding story for {badge} badge");
         AW.ArtixWeddingComplete();
-        
+
     }
 
     private string badge = "Lord of the Wedding Ring";

--- a/Other/Badges/MummySlayerAndCruxShadowsDefender.cs
+++ b/Other/Badges/MummySlayerAndCruxShadowsDefender.cs
@@ -20,7 +20,7 @@ public class MummySlayerAndCruxShadowsDefender
 
     public void Badge()
     {
-        if (Core.HasWebBadge("Mummy Slayer") || Core.HasWebBadge("CruxShadows Defender")) 
+        if (Core.HasWebBadge("Mummy Slayer") || Core.HasWebBadge("CruxShadows Defender"))
         {
             Core.Logger("Already have the Mummy Slayer and CruxShadows Defender badge");
             return;

--- a/Other/Badges/ShadowVaultChampion.cs
+++ b/Other/Badges/ShadowVaultChampion.cs
@@ -29,7 +29,7 @@ public class ShadowVaultChampion
 
         Core.Logger($"Doing ShadowVault story for {badge} badge");
         SV.StoryLine();
-        
+
     }
 
     private string badge = "ShadowScythe Champion";

--- a/Other/Classes/LevelAllClasses.cs
+++ b/Other/Classes/LevelAllClasses.cs
@@ -21,7 +21,8 @@ public class CoreClass
     public void Level()
     {
         List<InventoryItem> itemInv = Bot.Inventory.Items.FindAll(i => i.Category == ItemCategory.Class && i.Quantity != 302500);
-        foreach (InventoryItem item in itemInv) {
+        foreach (InventoryItem item in itemInv)
+        {
             Core.Logger($"Leveling {item.Name} class");
             Adv.rankUpClass(item.Name);
         }

--- a/Other/DragonCrystal[Upholder].cs
+++ b/Other/DragonCrystal[Upholder].cs
@@ -22,7 +22,7 @@ public class DragonCristal
     public void Quantity(int quant = 5000)
     {
         DragonRoad.StoryLine();
-        
+
         Core.RegisterQuests(4549);
         while (!Bot.ShouldExit && !Core.CheckInventory("Dragon Crystal", quant))
         {

--- a/Other/ElementalDragonSlayer.cs
+++ b/Other/ElementalDragonSlayer.cs
@@ -56,7 +56,7 @@ public class ElementalDragonSlayer
                 Core.HuntMonster("maloth", "Maloth", "Key of Envy", isTemp: false);
                 Core.HuntMonster("wrath", "Gorgorath", "Key of Wrath", isTemp: false);
 
-                Core.EnsureCompleteChoose(6171, new[] {SetItems[i]});
+                Core.EnsureCompleteChoose(6171, new[] { SetItems[i] });
                 Bot.Wait.ForPickup(SetItems[i]);
             }
         }

--- a/Other/GachaponMachineQuests.cs
+++ b/Other/GachaponMachineQuests.cs
@@ -83,7 +83,7 @@ public class GachaponMachine
         "A Story of Eden: Light Novel",
         "A Story of Eden: Special Edition",
     };
-    
+
     public void Gacha()
     {
         Eden.StoryLine();

--- a/Other/Jir'abinChallenge.cs
+++ b/Other/Jir'abinChallenge.cs
@@ -83,7 +83,7 @@ public class JirabinChallenge
     {
         if (Core.isCompletedBefore(4005))
             return;
-            
+
         RunedWoods();
 
         Story.PreLoad(this);

--- a/Other/MergeShops/3LittleWolvesHousesMerge.cs
+++ b/Other/MergeShops/3LittleWolvesHousesMerge.cs
@@ -24,18 +24,18 @@ public class ThreeLittleWolvesHousesMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Building Material", "Foundation Material", "Decor Material", "Dragonrune Blueprint", "Mana Golem's Core", "Arcangrove Blueprint", "Falcontower Blueprint", "Citadel Caverns Blueprint", "Citadel Blueprint", "Seraphic Blueprint", "Hachiko Blueprint", "Clubhouse Blueprint "});
+        Core.BankingBlackList.AddRange(new[] { "Building Material", "Foundation Material", "Decor Material", "Dragonrune Blueprint", "Mana Golem's Core", "Arcangrove Blueprint", "Falcontower Blueprint", "Citadel Caverns Blueprint", "Citadel Blueprint", "Seraphic Blueprint", "Hachiko Blueprint", "Clubhouse Blueprint " });
         Core.SetOptions();
- 
+
         BuyAllMerge();
 
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("buyhouse", 1729, findIngredients);
+        Adv.StartBuyAllMerge("buyhouse", 1729, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/4DPyramidHouseMerge.cs
+++ b/Other/MergeShops/4DPyramidHouseMerge.cs
@@ -26,7 +26,7 @@ public class FourDPyramidHouseShop
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Anti-Matter Gem "});
+        Core.BankingBlackList.AddRange(new[] { "Anti-Matter Gem " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -34,13 +34,13 @@ public class FourDPyramidHouseShop
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         TOD.FourthDimensionalPyramid();
         Farm.EternalREP();
 
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("fourdpyramid", 1276, findIngredients);
+        Adv.StartBuyAllMerge("fourdpyramid", 1276, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/AQWorldsWarZMerge.cs
+++ b/Other/MergeShops/AQWorldsWarZMerge.cs
@@ -24,7 +24,7 @@ public class AQWorldsWarZMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Angry Zombie Skull "});
+        Core.BankingBlackList.AddRange(new[] { "Angry Zombie Skull " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -32,10 +32,10 @@ public class AQWorldsWarZMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("doomwar", 665, findIngredients);
+        Adv.StartBuyAllMerge("doomwar", 665, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/AprilFools2019WarMerge.cs
+++ b/Other/MergeShops/AprilFools2019WarMerge.cs
@@ -24,7 +24,7 @@ public class AprilFools2019WarMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Punadin Badge "});
+        Core.BankingBlackList.AddRange(new[] { "Punadin Badge " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -32,10 +32,10 @@ public class AprilFools2019WarMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("pal9001", 1709, findIngredients);
+        Adv.StartBuyAllMerge("pal9001", 1709, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/ArchFiendWarlordMerge.cs
+++ b/Other/MergeShops/ArchFiendWarlordMerge.cs
@@ -37,10 +37,10 @@ public class ArchFiendWarlordMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("tercessuinotlim", 1820, findIngredients);
+        Adv.StartBuyAllMerge("tercessuinotlim", 1820, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/ArtixWeddingMerge.cs
+++ b/Other/MergeShops/ArtixWeddingMerge.cs
@@ -24,7 +24,7 @@ public class ArtixWeddingMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Love Token "});
+        Core.BankingBlackList.AddRange(new[] { "Love Token " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -32,10 +32,10 @@ public class ArtixWeddingMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("battlewedding", 788, findIngredients);
+        Adv.StartBuyAllMerge("battlewedding", 788, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/AshfallCampMerge.cs
+++ b/Other/MergeShops/AshfallCampMerge.cs
@@ -32,10 +32,10 @@ public class AshfallCampMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("ashfallcamp", 1422, findIngredients);
+        Adv.StartBuyAllMerge("ashfallcamp", 1422, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/BarricadeDefenseMerge.cs
+++ b/Other/MergeShops/BarricadeDefenseMerge.cs
@@ -26,7 +26,7 @@ public class BarricadeDefenseMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Rift Defense Medal "});
+        Core.BankingBlackList.AddRange(new[] { "Rift Defense Medal " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -34,12 +34,12 @@ public class BarricadeDefenseMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         QOM.TheDestroyer();
 
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("greenguardeast", 1401, findIngredients);
+        Adv.StartBuyAllMerge("greenguardeast", 1401, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/BattleConGearMerge.cs
+++ b/Other/MergeShops/BattleConGearMerge.cs
@@ -24,7 +24,7 @@ public class BattleConGearMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "DeadMog LED "});
+        Core.BankingBlackList.AddRange(new[] { "DeadMog LED " });
         Core.SetOptions();
 
         BuyAllMerge();

--- a/Other/MergeShops/BeleensChaosFuzzyMerge.cs
+++ b/Other/MergeShops/BeleensChaosFuzzyMerge.cs
@@ -26,7 +26,7 @@ public class BeleensChaosFuzzyMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Chaos Fuzzies "});
+        Core.BankingBlackList.AddRange(new[] { "Chaos Fuzzies " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -34,12 +34,12 @@ public class BeleensChaosFuzzyMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         Summer.Beleen();
 
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("pastelia", 135, findIngredients);
+        Adv.StartBuyAllMerge("pastelia", 135, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/BeleensMerge.cs
+++ b/Other/MergeShops/BeleensMerge.cs
@@ -46,10 +46,10 @@ public class BeleensMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("tower", 347, findIngredients);
+        Adv.StartBuyAllMerge("tower", 347, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/BidoBirthdayMerge.cs
+++ b/Other/MergeShops/BidoBirthdayMerge.cs
@@ -31,10 +31,10 @@ public class BidoBirthdayMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("akiba", 1735, findIngredients);
+        Adv.StartBuyAllMerge("akiba", 1735, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/BlackHoleSunMerge.cs
+++ b/Other/MergeShops/BlackHoleSunMerge.cs
@@ -31,10 +31,10 @@ public class BlackHoleSunMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("blackholesun", 1268, findIngredients);
+        Adv.StartBuyAllMerge("blackholesun", 1268, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/BloodAncientMerge.cs
+++ b/Other/MergeShops/BloodAncientMerge.cs
@@ -34,10 +34,10 @@ public class BloodAncientMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("safiria", 391, findIngredients);
+        Adv.StartBuyAllMerge("safiria", 391, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/BloodMoonVampireMerge.cs
+++ b/Other/MergeShops/BloodMoonVampireMerge.cs
@@ -34,12 +34,12 @@ public class BloodMoonVampireMergeTemp
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         BloodMoonQuests.BloodMoonSaga();
 
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("bloodwarvamp", 1489, findIngredients);
+        Adv.StartBuyAllMerge("bloodwarvamp", 1489, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/BloodTitanMerge[mem].cs
+++ b/Other/MergeShops/BloodTitanMerge[mem].cs
@@ -30,13 +30,13 @@ public class BloodTitanMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.IsMember)
             return;
 
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("classhalla", 617, findIngredients);
+        Adv.StartBuyAllMerge("classhalla", 617, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/BloodWarLycanMerge.cs
+++ b/Other/MergeShops/BloodWarLycanMerge.cs
@@ -34,11 +34,11 @@ public class BloodWarLycanMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         BloodMoonQuests.BloodMoonSaga();
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("bloodwarlycan", 1488, findIngredients);
+        Adv.StartBuyAllMerge("bloodwarlycan", 1488, findIngredients, buyOnlyThis, buyMode: buyMode);
         #region Dont edit this part
         void findIngredients()
         {

--- a/Other/MergeShops/BoneTowersMerge.cs
+++ b/Other/MergeShops/BoneTowersMerge.cs
@@ -34,12 +34,12 @@ public class TowersMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         TOD.BoneTowerAll();
 
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("towersilver", 1243, findIngredients);
+        Adv.StartBuyAllMerge("towersilver", 1243, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/BonecastleMerge.cs
+++ b/Other/MergeShops/BonecastleMerge.cs
@@ -34,10 +34,10 @@ public class BonecastleMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("bonecastle", 1242, findIngredients);
+        Adv.StartBuyAllMerge("bonecastle", 1242, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/BrightForestMerge.cs
+++ b/Other/MergeShops/BrightForestMerge.cs
@@ -34,10 +34,10 @@ public class BrightForestMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("brightforest", 1911, findIngredients);
+        Adv.StartBuyAllMerge("brightforest", 1911, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/BrightshadowMerge.cs
+++ b/Other/MergeShops/BrightshadowMerge.cs
@@ -34,11 +34,11 @@ public class BrightshadowMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         SoC.BrightShadow();
         SoC.BrightChaos();
-        Adv.StartBuyAllMerge("brightshadow", 1921, findIngredients);
+        Adv.StartBuyAllMerge("brightshadow", 1921, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/CelestialChallengerMerge.cs
+++ b/Other/MergeShops/CelestialChallengerMerge.cs
@@ -32,10 +32,10 @@ public class CelestialChallengerMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("celestialarena", 1473, findIngredients);
+        Adv.StartBuyAllMerge("celestialarena", 1473, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/CelestialPastMerge.cs
+++ b/Other/MergeShops/CelestialPastMerge.cs
@@ -32,10 +32,10 @@ public class CelestialPastMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("celestialpast", 1909, findIngredients);
+        Adv.StartBuyAllMerge("celestialpast", 1909, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/CelestialRealmMerge.cs
+++ b/Other/MergeShops/CelestialRealmMerge.cs
@@ -34,10 +34,10 @@ public class CelestialRealmMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("celestialrealm", 132, findIngredients);
+        Adv.StartBuyAllMerge("celestialrealm", 132, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/CelestialSpoilsMerge.cs
+++ b/Other/MergeShops/CelestialSpoilsMerge.cs
@@ -36,10 +36,10 @@ public class CelestialSpoilsMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("djinnguard", 1582, findIngredients);
+        Adv.StartBuyAllMerge("djinnguard", 1582, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/ChaosWarMerge.cs
+++ b/Other/MergeShops/ChaosWarMerge.cs
@@ -22,7 +22,7 @@ public class ChaosWarMerge
 
     public void ScriptMain(IScriptInterface Bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Chaos Eye", "Chaos Tentacle "});
+        Core.BankingBlackList.AddRange(new[] { "Chaos Eye", "Chaos Tentacle " });
         Core.SetOptions();
 
         BuyAllMerge();

--- a/Other/MergeShops/CharonsPurgeMerge.cs
+++ b/Other/MergeShops/CharonsPurgeMerge.cs
@@ -38,13 +38,13 @@ public class CharonsPurgeMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         CoreIsleOfFotia.CompleteALL();
         Adv.AltFarmItems.Add("Psyche");
 
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("styx", 670, findIngredients);
+        Adv.StartBuyAllMerge("styx", 670, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/ChronoMerge.cs
+++ b/Other/MergeShops/ChronoMerge.cs
@@ -31,10 +31,10 @@ public class ChronoMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("chronohub", 2011, findIngredients);
+        Adv.StartBuyAllMerge("chronohub", 2011, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/CommitedMerge.cs
+++ b/Other/MergeShops/CommitedMerge.cs
@@ -36,11 +36,11 @@ public class CommitedMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
         Asylum.StoryLine();
-        Adv.StartBuyAllMerge("asylum", 506, findIngredients);
+        Adv.StartBuyAllMerge("asylum", 506, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/CraggleRockMerge.cs
+++ b/Other/MergeShops/CraggleRockMerge.cs
@@ -31,10 +31,10 @@ public class CraggleRockMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("cragglerock", 1819, findIngredients);
+        Adv.StartBuyAllMerge("cragglerock", 1819, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/Crownsreach50ChestMerge.cs
+++ b/Other/MergeShops/Crownsreach50ChestMerge.cs
@@ -36,10 +36,10 @@ public class Crownsreach50ChestMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("chaosamulet", 1915, findIngredients);
+        Adv.StartBuyAllMerge("chaosamulet", 1915, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/CrownsreachDefenseMerge.cs
+++ b/Other/MergeShops/CrownsreachDefenseMerge.cs
@@ -38,11 +38,11 @@ public class CrownsreachDefenseMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         SoW.ShadowWar();
         SoC.DualPlane();
-        Adv.StartBuyAllMerge("chaosamulet", 1914, findIngredients);
+        Adv.StartBuyAllMerge("chaosamulet", 1914, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/CruxShadowsMerge.cs
+++ b/Other/MergeShops/CruxShadowsMerge.cs
@@ -33,10 +33,10 @@ public class CruxShadowsMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("cruxship", 1172, findIngredients);
+        Adv.StartBuyAllMerge("cruxship", 1172, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/DageRecruitMerge.cs
+++ b/Other/MergeShops/DageRecruitMerge.cs
@@ -39,10 +39,10 @@ public class DageRecruitMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("dagerecruit", 2119, findIngredients);
+        Adv.StartBuyAllMerge("dagerecruit", 2119, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/DarkHandMerge.cs
+++ b/Other/MergeShops/DarkHandMerge.cs
@@ -31,10 +31,10 @@ public class DarkHandMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("legionarena", 1693, findIngredients);
+        Adv.StartBuyAllMerge("legionarena", 1693, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/DarkPalaceMerge.cs
+++ b/Other/MergeShops/DarkPalaceMerge.cs
@@ -34,10 +34,10 @@ public class DarkPalaceMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("dagefortress", 1144, findIngredients);
+        Adv.StartBuyAllMerge("dagefortress", 1144, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/DarkbloodWarMerge.cs
+++ b/Other/MergeShops/DarkbloodWarMerge.cs
@@ -33,11 +33,11 @@ public class DarkbloodWarMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         QOM.CompleteEverything();
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("kolyaban", 1420, findIngredients);
+        Adv.StartBuyAllMerge("kolyaban", 1420, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/DeadLinesMerge.cs
+++ b/Other/MergeShops/DeadLinesMerge.cs
@@ -35,10 +35,10 @@ public class DeadLinesMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("deadlines", 2169, findIngredients);
+        Adv.StartBuyAllMerge("deadlines", 2169, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/DeadflyMerge.cs
+++ b/Other/MergeShops/DeadflyMerge.cs
@@ -34,10 +34,10 @@ public class DeadflyMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("deadfly", 2037, findIngredients);
+        Adv.StartBuyAllMerge("deadfly", 2037, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()
@@ -86,7 +86,7 @@ public class DeadflyMerge
                     Core.EquipClass(ClassType.Solo);
                     Core.HuntMonster("RotFinger", "Rotfinger", req.Name, isTemp: false);
                     break;
-                
+
             }
         }
     }

--- a/Other/MergeShops/DeathPitArenaRepMerge.cs
+++ b/Other/MergeShops/DeathPitArenaRepMerge.cs
@@ -24,7 +24,7 @@ public class DeathPitArenaRepMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Death Pit Arena Medal", "General Gall Medal", "General Velm Medal", "General Hun'Gar Medal", "General Chud Medal "});
+        Core.BankingBlackList.AddRange(new[] { "Death Pit Arena Medal", "General Gall Medal", "General Velm Medal", "General Hun'Gar Medal", "General Chud Medal " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -32,10 +32,10 @@ public class DeathPitArenaRepMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("deathpit", 1261, findIngredients);
+        Adv.StartBuyAllMerge("deathpit", 1261, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/DeerHuntMerge[non-ac].cs
+++ b/Other/MergeShops/DeerHuntMerge[non-ac].cs
@@ -26,7 +26,7 @@ public class DeerHuntMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Icy Pelt", "WinterWild Axe", "Old Moglin Teddy Mace "});
+        Core.BankingBlackList.AddRange(new[] { "Icy Pelt", "WinterWild Axe", "Old Moglin Teddy Mace " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -34,12 +34,12 @@ public class DeerHuntMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         DeerHunt.StoryLine();
 
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("deerhunt", 2077, findIngredients);
+        Adv.StartBuyAllMerge("deerhunt", 2077, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()
@@ -74,7 +74,7 @@ public class DeerHuntMerge
                     }
                     Core.CancelRegisteredQuests();
                     break;
-                
+
                 case "WinterWild Axe":
                 case "Old Moglin Teddy Mace":
                     Core.FarmingLogger(req.Name, quant);

--- a/Other/MergeShops/DoomLegacyMerge.cs
+++ b/Other/MergeShops/DoomLegacyMerge.cs
@@ -34,10 +34,10 @@ public class DoomLegacyMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("stonewood", 1899, findIngredients);
+        Adv.StartBuyAllMerge("stonewood", 1899, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/DragonSoulShinobiMerge.cs
+++ b/Other/MergeShops/DragonSoulShinobiMerge.cs
@@ -34,10 +34,10 @@ public class DragonSoulShinobiMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("shadowfortress", 1968, findIngredients);
+        Adv.StartBuyAllMerge("shadowfortress", 1968, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/DreadForestMerge.cs
+++ b/Other/MergeShops/DreadForestMerge.cs
@@ -31,10 +31,10 @@ public class DreadForestMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("dreadforest", 2140, findIngredients);
+        Adv.StartBuyAllMerge("dreadforest", 2140, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/DreadspaceReplicatorMerge.cs
+++ b/Other/MergeShops/DreadspaceReplicatorMerge.cs
@@ -34,10 +34,10 @@ public class DreadspaceReplicatorMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         Dread.DreadSpace(true);
-        Adv.StartBuyAllMerge("dreadspace", 527, findIngredients);
+        Adv.StartBuyAllMerge("dreadspace", 527, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/DreampalaceMerge.cs
+++ b/Other/MergeShops/DreampalaceMerge.cs
@@ -32,10 +32,10 @@ public class DreampalaceMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("dreampalace", 1961, findIngredients);
+        Adv.StartBuyAllMerge("dreampalace", 1961, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/DruidMerge.cs
+++ b/Other/MergeShops/DruidMerge.cs
@@ -31,10 +31,10 @@ public class DruidMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("arcangrove", 2003, findIngredients);
+        Adv.StartBuyAllMerge("arcangrove", 2003, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/DwobosMerge.cs
+++ b/Other/MergeShops/DwobosMerge.cs
@@ -32,10 +32,10 @@ public class DwobosMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("crashruins", 1212, findIngredients);
+        Adv.StartBuyAllMerge("crashruins", 1212, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()
@@ -71,7 +71,7 @@ public class DwobosMerge
                             Core.KillMonster("crashruins", "r2", "Left", "Spacetime Anomaly", "Pieces of Future Tech", 7);
                         else Core.KillMonster("crashruins", "r2", "Left", "Spacetime Anomaly", "Pieces of Future Tech", 5);
 
-                            Core.HuntMonster("crashruins", "Cluckmoo Idol", "Idol Heart");
+                        Core.HuntMonster("crashruins", "Cluckmoo Idol", "Idol Heart");
 
                         Bot.Wait.ForPickup(req.Name);
                     }

--- a/Other/MergeShops/ExtinctionGamesMerge.cs
+++ b/Other/MergeShops/ExtinctionGamesMerge.cs
@@ -22,7 +22,7 @@ public class ExtinctionGamesMerge
 
     public void ScriptMain(IScriptInterface Bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Burningjay Feather", "Coal", "Fabric Scraps", "Iron II.0", "A Kitten? "});
+        Core.BankingBlackList.AddRange(new[] { "Burningjay Feather", "Coal", "Fabric Scraps", "Iron II.0", "A Kitten? " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -30,10 +30,10 @@ public class ExtinctionGamesMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("extinction", 1025, findIngredients);
+        Adv.StartBuyAllMerge("extinction", 1025, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/ExtraCreditMerge[non-ac].cs
+++ b/Other/MergeShops/ExtraCreditMerge[non-ac].cs
@@ -31,10 +31,10 @@ public class ExtraCreditMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("extracredit", 2158, findIngredients);
+        Adv.StartBuyAllMerge("extracredit", 2158, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/FiendPastMerge.cs
+++ b/Other/MergeShops/FiendPastMerge.cs
@@ -34,10 +34,10 @@ public class FiendPastMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("fiendpast", 2106, findIngredients);
+        Adv.StartBuyAllMerge("fiendpast", 2106, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/FirePlaneWarMerge.cs
+++ b/Other/MergeShops/FirePlaneWarMerge.cs
@@ -33,10 +33,10 @@ public class FirePlaneWarMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("fireplanewar", 2006, findIngredients);
+        Adv.StartBuyAllMerge("fireplanewar", 2006, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/FireandIceMerge.cs
+++ b/Other/MergeShops/FireandIceMerge.cs
@@ -33,11 +33,11 @@ public class FireandIceMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         DFO.DragonFableOriginsAll();
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("drakonnan", 1596, findIngredients);
+        Adv.StartBuyAllMerge("drakonnan", 1596, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()
@@ -68,9 +68,9 @@ public class FireandIceMerge
                         Core.HuntMonster("drakonnan", "Fire Dragon", "Dragon Scale");
                         Core.HuntMonster("drakonnan", "Living Fire", "Ember of a Living Flame");
                         Core.HuntMonster("drakonnan", "Fire Elemental", "Fire Elemental's Gauntlet");
-                        Core.HuntMonster("drakonnan", "Living Lava", "Lava Rock");                     
+                        Core.HuntMonster("drakonnan", "Living Lava", "Lava Rock");
                     }
-                     Core.CancelRegisteredQuests();
+                    Core.CancelRegisteredQuests();
                     break;
 
                 case "Ice Katana":

--- a/Other/MergeShops/GachaponMerge.cs
+++ b/Other/MergeShops/GachaponMerge.cs
@@ -27,7 +27,7 @@ public class GachaponMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Second Chance Coin "});
+        Core.BankingBlackList.AddRange(new[] { "Second Chance Coin " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -35,11 +35,11 @@ public class GachaponMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         Eden.StoryLine();
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("onsen", 1926, findIngredients);
+        Adv.StartBuyAllMerge("onsen", 1926, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/GonnaGetchaMerge.cs
+++ b/Other/MergeShops/GonnaGetchaMerge.cs
@@ -33,12 +33,12 @@ public class GonnaGetchaMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         F13.Gonnagetcha();
 
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("gonnagetcha", 1581, findIngredients);
+        Adv.StartBuyAllMerge("gonnagetcha", 1581, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/GooseMerge.cs
+++ b/Other/MergeShops/GooseMerge.cs
@@ -24,7 +24,7 @@ public class GooseMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Cysero's Cookie "});
+        Core.BankingBlackList.AddRange(new[] { "Cysero's Cookie " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -32,10 +32,10 @@ public class GooseMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("goose", 58, findIngredients);
+        Adv.StartBuyAllMerge("goose", 58, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/HallofClassesMerge.cs
+++ b/Other/MergeShops/HallofClassesMerge.cs
@@ -32,10 +32,10 @@ public class HallofClassesMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("classhall", 1876, findIngredients);
+        Adv.StartBuyAllMerge("classhall", 1876, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/IceDungeonMerge.cs
+++ b/Other/MergeShops/IceDungeonMerge.cs
@@ -34,10 +34,10 @@ public class IceDungeonMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("icedungeon", 1948, findIngredients);
+        Adv.StartBuyAllMerge("icedungeon", 1948, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/KagesMerge[mem-non-ac].cs
+++ b/Other/MergeShops/KagesMerge[mem-non-ac].cs
@@ -26,7 +26,7 @@ public class KagesMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Jade Box Trinket", "Jade Box Jewel", "Jade Box Heirloom "});
+        Core.BankingBlackList.AddRange(new[] { "Jade Box Trinket", "Jade Box Jewel", "Jade Box Heirloom " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -34,12 +34,12 @@ public class KagesMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         Nukemichi.NukemichiQuests();
 
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("akiba", 355, findIngredients);
+        Adv.StartBuyAllMerge("akiba", 355, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/LegionPyromancerMerge.cs
+++ b/Other/MergeShops/LegionPyromancerMerge.cs
@@ -36,10 +36,10 @@ public class LegionPyromancerMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("underworld", 1734, findIngredients);
+        Adv.StartBuyAllMerge("underworld", 1734, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/MazeMerge.cs
+++ b/Other/MergeShops/MazeMerge.cs
@@ -32,10 +32,10 @@ public class MazeMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("whitehole", 1273, findIngredients);
+        Adv.StartBuyAllMerge("whitehole", 1273, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/MirrorRealmMerge.cs
+++ b/Other/MergeShops/MirrorRealmMerge.cs
@@ -34,10 +34,10 @@ public class MirrorRealmMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("mirrorportal", 618, findIngredients);
+        Adv.StartBuyAllMerge("mirrorportal", 618, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/NavalTopHatMerge.cs
+++ b/Other/MergeShops/NavalTopHatMerge.cs
@@ -32,10 +32,10 @@ public class NavalTopHatMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("pirates", 723, findIngredients);
+        Adv.StartBuyAllMerge("pirates", 723, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/NightmareCarnaxMerge.cs
+++ b/Other/MergeShops/NightmareCarnaxMerge.cs
@@ -47,11 +47,11 @@ public class NightmareCarnaxMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         DarkCarnax.Storyline(true);
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("darkcarnax", 2170, findIngredients);
+        Adv.StartBuyAllMerge("darkcarnax", 2170, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/OrbHuntMerge.cs
+++ b/Other/MergeShops/OrbHuntMerge.cs
@@ -33,10 +33,10 @@ public class OrbHuntMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("orbhunt", 2060, findIngredients);
+        Adv.StartBuyAllMerge("orbhunt", 2060, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/OriginulMerge.cs
+++ b/Other/MergeShops/OriginulMerge.cs
@@ -34,10 +34,10 @@ public class OriginulMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("originul", 1962, findIngredients);
+        Adv.StartBuyAllMerge("originul", 1962, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/ParadoxPortalMerge.cs
+++ b/Other/MergeShops/ParadoxPortalMerge.cs
@@ -24,7 +24,7 @@ public class ParadoxPortalMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Paradox Core", "Time Heart", "Paradox Gem "});
+        Core.BankingBlackList.AddRange(new[] { "Paradox Core", "Time Heart", "Paradox Gem " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -32,10 +32,10 @@ public class ParadoxPortalMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("portalmaze", 1248, findIngredients);
+        Adv.StartBuyAllMerge("portalmaze", 1248, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/PlagueGearMerge.cs
+++ b/Other/MergeShops/PlagueGearMerge.cs
@@ -33,11 +33,11 @@ public class PlagueGearMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         DD.Sloth();
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("sloth", 1429, findIngredients);
+        Adv.StartBuyAllMerge("sloth", 1429, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/QueensReignMerge.cs
+++ b/Other/MergeShops/QueensReignMerge.cs
@@ -24,7 +24,7 @@ public class QueensReignMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Ancient Hourglass", "LightningLord", "LightningLord Helm", "LightningLord Locks", "LightningLord Rune "});
+        Core.BankingBlackList.AddRange(new[] { "Ancient Hourglass", "LightningLord", "LightningLord Helm", "LightningLord Locks", "LightningLord Rune " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -32,10 +32,10 @@ public class QueensReignMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("queenreign", 2058, findIngredients);
+        Adv.StartBuyAllMerge("queenreign", 2058, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/RangdaMerge.cs
+++ b/Other/MergeShops/RangdaMerge.cs
@@ -31,10 +31,10 @@ public class RangdaMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("rangda", 1901, findIngredients);
+        Adv.StartBuyAllMerge("rangda", 1901, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/RuinedCrownMerge.cs
+++ b/Other/MergeShops/RuinedCrownMerge.cs
@@ -34,11 +34,11 @@ public class RuinedCrownMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         SoW.RuinedCrown();
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("ruinedcrown", 2156, findIngredients);
+        Adv.StartBuyAllMerge("ruinedcrown", 2156, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/ShadowFirePlaneMerge.cs
+++ b/Other/MergeShops/ShadowFirePlaneMerge.cs
@@ -34,10 +34,10 @@ public class ShadowFirePlaneMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("shadowfireplane", 2008, findIngredients);
+        Adv.StartBuyAllMerge("shadowfireplane", 2008, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/ShadowScytheGeneralMerge.cs
+++ b/Other/MergeShops/ShadowScytheGeneralMerge.cs
@@ -34,10 +34,10 @@ public class ShadowScytheGeneralMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("shadowfall", 1644, findIngredients);
+        Adv.StartBuyAllMerge("shadowfall", 1644, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/ShadowSlayerKMerge.cs
+++ b/Other/MergeShops/ShadowSlayerKMerge.cs
@@ -41,7 +41,7 @@ public class ShadowSlayerKMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         var result = Bot.ShowMessageBox("Items containing the word \"Shadow\" in this shop cost 1 Elders' Blood per piece, " +
                                                 "which is a valuable resource used to get Void Highlord. Are you sure you want to continue?",
@@ -50,7 +50,7 @@ public class ShadowSlayerKMerge
             return;
 
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("safiria", 2044, findIngredients);
+        Adv.StartBuyAllMerge("safiria", 2044, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/ShadowfallDefenseMerge.cs
+++ b/Other/MergeShops/ShadowfallDefenseMerge.cs
@@ -35,10 +35,10 @@ public class ShadowfallDefenseMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("shadowgates", 803, findIngredients);
+        Adv.StartBuyAllMerge("shadowgates", 803, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/ShadowofChaosMerge.cs
+++ b/Other/MergeShops/ShadowofChaosMerge.cs
@@ -34,10 +34,10 @@ public class ShadowofChaosMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         Laguna.LagunaBeach();
-        Adv.StartBuyAllMerge("laguna", 1917, findIngredients);
+        Adv.StartBuyAllMerge("laguna", 1917, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/ShadowrealmMerge.cs
+++ b/Other/MergeShops/ShadowrealmMerge.cs
@@ -31,10 +31,10 @@ public class ShadowrealmMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("shadowrealm", 1889, findIngredients);
+        Adv.StartBuyAllMerge("shadowrealm", 1889, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/ShinkansenMerge.cs
+++ b/Other/MergeShops/ShinkansenMerge.cs
@@ -34,10 +34,10 @@ public class ShinkansenMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("shinkansen", 2005, findIngredients);
+        Adv.StartBuyAllMerge("shinkansen", 2005, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/ShipWreckMerge[non-ac].cs
+++ b/Other/MergeShops/ShipWreckMerge[non-ac].cs
@@ -26,7 +26,7 @@ public class ShipWreckMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Enchanted Gauntlet Leather", "Anti-Au Crystals "});
+        Core.BankingBlackList.AddRange(new[] { "Enchanted Gauntlet Leather", "Anti-Au Crystals " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -34,12 +34,12 @@ public class ShipWreckMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         ShipWreck.StoryLine();
 
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("shipwreck", 105, findIngredients);
+        Adv.StartBuyAllMerge("shipwreck", 105, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/SkullbreakerKnightMerge.cs
+++ b/Other/MergeShops/SkullbreakerKnightMerge.cs
@@ -28,10 +28,10 @@ public class SkullbreakerKnightMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("stonewood", 2071, findIngredients);
+        Adv.StartBuyAllMerge("stonewood", 2071, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/SpoilsofLightMerge.cs
+++ b/Other/MergeShops/SpoilsofLightMerge.cs
@@ -44,10 +44,10 @@ public class SpoilsofLightMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("lightguardwar", 1643, findIngredients);
+        Adv.StartBuyAllMerge("lightguardwar", 1643, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()
@@ -97,7 +97,7 @@ public class SpoilsofLightMerge
                     }
                     Core.CancelRegisteredQuests();
                     break;
-                   
+
                 case "Medal of Honor":
                     Core.FarmingLogger(req.Name, quant);
                     Core.EquipClass(ClassType.Farm);

--- a/Other/MergeShops/StreamwarMerge.cs
+++ b/Other/MergeShops/StreamwarMerge.cs
@@ -33,11 +33,11 @@ public class StreamwarMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         SoW.CompleteCoreSoW();
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("streamwar", 2163, findIngredients);
+        Adv.StartBuyAllMerge("streamwar", 2163, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/SuperDeathMerge.cs
+++ b/Other/MergeShops/SuperDeathMerge.cs
@@ -34,10 +34,10 @@ public class SuperDeathMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         SuperDeath.StoryLine();
-        Adv.StartBuyAllMerge("superdeath", 1992, findIngredients);
+        Adv.StartBuyAllMerge("superdeath", 1992, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/SynderesMerge.cs
+++ b/Other/MergeShops/SynderesMerge.cs
@@ -24,7 +24,7 @@ public class SynderesMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Synderes' Souvenir "});
+        Core.BankingBlackList.AddRange(new[] { "Synderes' Souvenir " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -32,10 +32,10 @@ public class SynderesMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("enemyforest", 332, findIngredients);
+        Adv.StartBuyAllMerge("enemyforest", 332, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/TechfortressWarMerge.cs
+++ b/Other/MergeShops/TechfortressWarMerge.cs
@@ -39,10 +39,10 @@ public class TechfortressWarMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("techfortress", 1902, findIngredients);
+        Adv.StartBuyAllMerge("techfortress", 1902, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/TerranesMerge.cs
+++ b/Other/MergeShops/TerranesMerge.cs
@@ -34,10 +34,10 @@ public class TerranesMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         QOM.TheReshaper(true);
-        Adv.StartBuyAllMerge("guardiantree", 1584, findIngredients);
+        Adv.StartBuyAllMerge("guardiantree", 1584, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/TimekeepMerge.cs
+++ b/Other/MergeShops/TimekeepMerge.cs
@@ -34,11 +34,11 @@ public class TimekeepMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         SoW.Timekeep();
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("timekeep", 2161, findIngredients);
+        Adv.StartBuyAllMerge("timekeep", 2161, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/TitanGearMerge.cs
+++ b/Other/MergeShops/TitanGearMerge.cs
@@ -31,10 +31,10 @@ public class TitanGearMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("titanattack", 2149, findIngredients);
+        Adv.StartBuyAllMerge("titanattack", 2149, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/TowerofWindsMerge.cs
+++ b/Other/MergeShops/TowerofWindsMerge.cs
@@ -34,10 +34,10 @@ public class TowerofWindsMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("glacera", 1055, findIngredients);
+        Adv.StartBuyAllMerge("glacera", 1055, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/TrickstersGiftsMerge.cs
+++ b/Other/MergeShops/TrickstersGiftsMerge.cs
@@ -32,10 +32,10 @@ public class TrickstersGiftsMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("mythperception", 1910, findIngredients);
+        Adv.StartBuyAllMerge("mythperception", 1910, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/TrygveMerge.cs
+++ b/Other/MergeShops/TrygveMerge.cs
@@ -34,10 +34,10 @@ public class TrygveMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         Trygve.Storyline();
-        Adv.StartBuyAllMerge("trygve", 2054, findIngredients);
+        Adv.StartBuyAllMerge("trygve", 2054, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/UbearMerge.cs
+++ b/Other/MergeShops/UbearMerge.cs
@@ -27,7 +27,7 @@ public class UbearMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Ubear X Pass", "Legion Token "});
+        Core.BankingBlackList.AddRange(new[] { "Ubear X Pass", "Legion Token " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -35,10 +35,10 @@ public class UbearMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("ubear", 1849, findIngredients);
+        Adv.StartBuyAllMerge("ubear", 1849, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/WarTrainingMerge.cs
+++ b/Other/MergeShops/WarTrainingMerge.cs
@@ -40,10 +40,10 @@ public class WarTrainingMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         Tynd.Tyndarius(true);
-        Adv.StartBuyAllMerge("wartraining", 2035, findIngredients);
+        Adv.StartBuyAllMerge("wartraining", 2035, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/WorldCoreMerge.cs
+++ b/Other/MergeShops/WorldCoreMerge.cs
@@ -31,7 +31,7 @@ public class WorldCoreMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
         Adv.StartBuyAllMerge("worldsoul", 1572, findIngredients, itemBlackList: new[] { "Core Guardian Bank" });

--- a/Other/MergeShops/WorldsCoreMerge.cs
+++ b/Other/MergeShops/WorldsCoreMerge.cs
@@ -34,11 +34,11 @@ public class WorldsCoreMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         SoW.ShadowFlame();
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("worldscore", 2182, findIngredients);
+        Adv.StartBuyAllMerge("worldscore", 2182, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/MergeShops/YulgarsDualWieldMerge.cs
+++ b/Other/MergeShops/YulgarsDualWieldMerge.cs
@@ -46,7 +46,7 @@ public class YulgarsDualWieldMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.CheckInventory("Golden 8th Birthday Candle"))
             Core.BuyItem(Bot.Map.Name, 1317, "Golden 8th Birthday Candle");
@@ -57,7 +57,7 @@ public class YulgarsDualWieldMerge
             return;
         }
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("nostalgiaquest", 1311, findIngredients);
+        Adv.StartBuyAllMerge("nostalgiaquest", 1311, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Other/SanctifiedArbiter.cs
+++ b/Other/SanctifiedArbiter.cs
@@ -27,7 +27,7 @@ public class SanctifiedArbiter
 
         if (Core.CheckInventory(Rewards))
             return;
-        
+
 
         for (int i = 0; i < Rewards.Count(); i++)
         {
@@ -40,7 +40,7 @@ public class SanctifiedArbiter
                 Core.EquipClass(ClassType.Farm);
                 Farm.BattleUnderB("Bone Dust", 500);
                 Core.HuntMonster("Doomwood", "Doomwood Ectomancer", "Raw Essence of the Undead", 10);
-        
+
                 Core.EnsureCompleteChoose(8114, new[] { Rewards[i] });
             }
             Core.ToBank(Rewards[i]);

--- a/Other/SpellRaiser[Member].cs
+++ b/Other/SpellRaiser[Member].cs
@@ -24,7 +24,7 @@ public class SpellRaiser
     {
         string[] AllRewards = (Core.EnsureLoad(7400).Rewards.Select(i => i.Name)).Concat(Core.EnsureLoad(7402).Rewards.Select(i => i.Name)).Concat(Core.EnsureLoad(7404).Rewards.Select(i => i.Name)).ToArray();
 
-       if (Core.CheckInventory(AllRewards, toInv: false))
+        if (Core.CheckInventory(AllRewards, toInv: false))
             return;
 
         CoreFriday13th.Splatterwar();

--- a/Other/TheLostKnightAndBackupBlade[Member].cs
+++ b/Other/TheLostKnightAndBackupBlade[Member].cs
@@ -27,7 +27,7 @@ public class TheLostKnightAndBackupBlade
 
         if (Core.CheckInventory(AllRewards, toInv: false))
             return;
-            
+
         CoreFriday13th.Splatterwar();
 
         Bot.Drops.Add(AllRewards);

--- a/Other/TrobbolierPet[Member].cs
+++ b/Other/TrobbolierPet[Member].cs
@@ -12,7 +12,7 @@ public class TrobbolierPet
     public void ScriptMain(IScriptInterface bot)
     {
         Core.SetOptions();
-        
+
         GetAll();
 
         Core.SetOptions(false);

--- a/Other/Various/BringTheCheer.cs
+++ b/Other/Various/BringTheCheer.cs
@@ -63,9 +63,9 @@ public class BringTheCheer
                 return;
             Core.FarmingLogger(item.Name, 1);
         }
-        
+
         Core.EquipClass(ClassType.Solo);
-        
+
         while (getAll ? !Core.CheckInventory(RewardOptions) : !Core.CheckInventory(item.Name))
         {
             Core.EnsureAccept(6651);

--- a/Other/Various/TheDarkBox.cs
+++ b/Other/Various/TheDarkBox.cs
@@ -42,6 +42,6 @@ public class TheDarkBox
             Core.ToBank(Rewards);
         }
         Core.CancelRegisteredQuests();
-        
+
     }
 }

--- a/Other/Various/UnderworldPirateCasterQuest.cs
+++ b/Other/Various/UnderworldPirateCasterQuest.cs
@@ -27,8 +27,8 @@ public class UnderWorldPirateCasterQuset
 
         string[] Rewards = (Core.EnsureLoad(7086).Rewards.Select(i => i.Name).ToArray());
         Core.AddDrop(Rewards);
-      
-        while(!Bot.ShouldExit && !Core.CheckInventory(Rewards, toInv: false))
+
+        while (!Bot.ShouldExit && !Core.CheckInventory(Rewards, toInv: false))
         {
             //Underworld Pirate Caster’s Pet Chest 7086
             Core.EnsureAccept(7086);

--- a/Other/Weapons/ChaorrupterUnlocked.cs
+++ b/Other/Weapons/ChaorrupterUnlocked.cs
@@ -41,7 +41,7 @@ public class ChaorrupterUnlocked
             Core.Logger("Farming Chaorrupter Unlocked (Free Player)");
             Core.KillMonster("chaoswar", "r2", "Spawn", "*", "Chaos Eye", 250, isTemp: false, log: false);
             Core.KillMonster("chaoswar", "r2", "Spawn", "*", "Chaos Tentacle", 250, isTemp: false, log: false);
-            Core.BuyItem("chaoswar", 642, 17932 , 1, 10986);
+            Core.BuyItem("chaoswar", 642, 17932, 1, 10986);
         }
         Adv.EnhanceItem("Chaorrupter Unlocked", EnhancementType.Lucky);
     }

--- a/Other/Weapons/EnchantedVictoryBladeWeapons.cs
+++ b/Other/Weapons/EnchantedVictoryBladeWeapons.cs
@@ -120,7 +120,7 @@ public class EnchantedVictoryBladeWeapons
 
         Core.HuntMonster("graveyard", "Skeletal Viking", "Nornir Triad Shard", 12, false);
 
-        Core.EnsureComplete(4813, type == "Amulet of Glory" ? 33502 : 33501); 
+        Core.EnsureComplete(4813, type == "Amulet of Glory" ? 33502 : 33501);
         // Core.EnsureComplete(4813, Amulet.ID); 
         Bot.Wait.ForPickup(type);
     }

--- a/Other/Weapons/ExaltedApotheosisPreReqs.cs
+++ b/Other/Weapons/ExaltedApotheosisPreReqs.cs
@@ -47,7 +47,7 @@ public class ExaltedApotheosisPreReqs
             Core.Logger("Got all prerequisites! Kill the ultra bosses manually\n" +
             "for insignias next to complete Exalted Apotheosis.");
         }
-        
+
         // if (Core.CheckInventory("Ezrajal Insignia", 24) && Core.CheckInventory("Warden Insignia", 24) && Core.CheckInventory("Engineer Insignia", 16))
         // {
         //     Core.Logger($"{Bot.Inventory.GetQuantity("Ezrajal Insignia") / 24}");

--- a/Other/Weapons/FortitudeAndHubris.cs
+++ b/Other/Weapons/FortitudeAndHubris.cs
@@ -28,15 +28,15 @@ public class FandH
         Story.PreLoad(this);
 
         Core.AddDrop(
-            "Zorbak's Secret G-Rave Key", 
-            "Sword's Cost", 
-            "Shards of the Sword", 
+            "Zorbak's Secret G-Rave Key",
+            "Sword's Cost",
+            "Shards of the Sword",
             "Hubris's Final Blade Shard",
-            "Hubris' Magic Essence", 
-            "Hubris", 
-            "Fortitude's Blade Shards", 
-            "Fortitude's Magic Essence", 
-            "Fortitude", 
+            "Hubris' Magic Essence",
+            "Hubris",
+            "Fortitude's Blade Shards",
+            "Fortitude's Magic Essence",
+            "Fortitude",
             "Fortitude + Hubris"
         );
 

--- a/Seasonal/AqwBirthday/20thAnniversary.cs
+++ b/Seasonal/AqwBirthday/20thAnniversary.cs
@@ -31,186 +31,186 @@ public class AnniversaryofDoom
         Spacepwny();
         Deathofgames();
     }
-    
-        public void Yulgarparty()
+
+    public void Yulgarparty()
+    {
+        if (Core.isCompletedBefore(8876))
+            return;
+
+        // 8874 Friends by the Fireplace
+        Story.MapItemQuest(8874, "yulgarparty", new[] { 10675, 10676, 10677, 10678, 10679, 10680, 10681, 10682, 10683 });
+
+        // 8875 Allies at the Entrance,
+        Story.MapItemQuest(8875, "yulgarparty", new[] { 10684, 10685, 10686, 10687, 10688, 10689, 10690 });
+
+        // 8876 Mates near the Music,
+        Story.MapItemQuest(8876, "yulgarparty", new[] { 10691, 10692, 10693, 10694, 10695, 10696, 10697, 10698, 10699 });
+    }
+    public void Zombae()
+    {
+        if (Core.isCompletedBefore(8883))
+            return;
+
+        Core.EquipClass(ClassType.Farm);
+
+        // 8877 O-(De)kay Cupid,
+        Story.KillQuest(8877, "zombae", "Bachelor");
+
+        // 8878 Ghosting my Ex-Goulfiends,
+        Story.KillQuest(8878, "zombae", "Bachelorette");
+
+        // 8879 You're Dead to Me,
+        Story.MapItemQuest(8879, "zombae", 10700);
+        Story.KillQuest(8879, "zombae", "Zombette");
+
+        // 8880 Swipe 4 Rich lich
+        Story.MapItemQuest(8880, "zombae", 10701);
+        Story.KillQuest(8880, "zombae", "Zombro");
+
+        // 8881 A Real Grave Digger
+        Story.MapItemQuest(8881, "zombae", 10702);
+        Story.KillQuest(8881, "zombae", "Zombroski");
+
+        // 8882 The Love of your Unlife
+        Story.MapItemQuest(8882, "zombae", 10703);
+        Story.KillQuest(8882, "zombae", "Zombetter");
+
+        Core.EquipClass(ClassType.Solo);
+        // 8883 The Ultimate Ghoul Fiend
+        Story.KillQuest(8883, "zombae", "Ghoul Fiend");
+    }
+    public void Mermaidsushi()
+    {
+        if (Core.isCompletedBefore(8892))
+            return;
+
+        Core.EquipClass(ClassType.Farm);
+        // 8884 S'KARIN WANT MOGLIN POPPERS,
+        Story.KillQuest(8884, "mermaidsushi", "Undead Moglin");
+
+        // 8885 S'KARIN WANT HAMSTEAK,
+        Story.KillQuest(8885, "mermaidsushi", "Haunted Hamster");
+
+        // 8886 S'KARIN WANT A SKELLO MOLD,
+        Story.KillQuest(8886, "mermaidsushi", "SkeleKitten");
+
+        // 8887 S'KARIN WANT OFFAL BIRD FOOD,
+        Story.KillQuest(8887, "mermaidsushi", "Undead Turkey");
+
+        Core.EquipClass(ClassType.Solo);
+        // 8888 S'KARIN WANT WINGS,
+        Story.KillQuest(8888, "mermaidsushi", "Dedbull");
+
+        // 8889 S'KARIN WANT MERMAID SUSHI 
+        Story.MapItemQuest(8889, "mermaidsushi", 10719);
+
+        // 8890 Mer-Angel Fish Food?!
+        Story.KillQuest(8890, "mermaidsushi", "Necro Minion");
+
+        // 8891 S'KARIN NO WANT GO VIRAL
+        Story.KillQuest(8891, "mermaidsushi", "Customer S'karin");
+
+        // 8892 Gore-Made for This
+        Story.KillQuest(8892, "mermaidsushi", "Die Fieri");
+    }
+    public void FREE500ACSPLEASE()
+    {
+        if (Core.isCompletedBefore(8893))
+            return;
+
+        Bot.Options.RestPackets = false;
+        Bot.Handlers.Remove("AFK Handler");
+
+        // 8893 AFK Quest
+        if (!Story.QuestProgression(8893))
         {
-            if (Core.isCompletedBefore(8876))
-                return;
-
-            // 8874 Friends by the Fireplace
-            Story.MapItemQuest(8874, "yulgarparty", new[] { 10675, 10676, 10677, 10678, 10679, 10680, 10681, 10682, 10683 });
-
-            // 8875 Allies at the Entrance,
-            Story.MapItemQuest(8875, "yulgarparty", new[] { 10684, 10685, 10686, 10687, 10688, 10689, 10690 });
-
-            // 8876 Mates near the Music,
-            Story.MapItemQuest(8876, "yulgarparty", new[] { 10691, 10692, 10693, 10694, 10695, 10696, 10697, 10698, 10699 });
+            Core.Join("afkquest");
+            Bot.Send.Packet("%xt%zm%afk%0%false%");
+            Core.Logger($"**DO NOT CLICK THE GAME SCREEN** this Will Take ~5minutes, Go touch some grass 👍");
+            Bot.Sleep(360000);
+            Core.Logger("Game Complete. You're Welcome for the Acs");
         }
-        public void Zombae()
+    }
+    public void Spacepwny()
+    {
+        if (Core.isCompletedBefore(8898))
+            return;
+
+        Bot.Options.RestPackets = true;
+
+        Core.EquipClass(ClassType.Farm);
+        // 8894 Plague of Zom-Bays
+        if (!Story.QuestProgression(8894))
         {
-            if (Core.isCompletedBefore(8883))
-                return;
-
-            Core.EquipClass(ClassType.Farm);
-
-            // 8877 O-(De)kay Cupid,
-            Story.KillQuest(8877, "zombae", "Bachelor");
-
-            // 8878 Ghosting my Ex-Goulfiends,
-            Story.KillQuest(8878, "zombae", "Bachelorette");
-
-            // 8879 You're Dead to Me,
-            Story.MapItemQuest(8879, "zombae", 10700);
-            Story.KillQuest(8879, "zombae", "Zombette");
-
-            // 8880 Swipe 4 Rich lich
-            Story.MapItemQuest(8880, "zombae", 10701);
-            Story.KillQuest(8880, "zombae", "Zombro");
-
-            // 8881 A Real Grave Digger
-            Story.MapItemQuest(8881, "zombae", 10702);
-            Story.KillQuest(8881, "zombae", "Zombroski");
-
-            // 8882 The Love of your Unlife
-            Story.MapItemQuest(8882, "zombae", 10703);
-            Story.KillQuest(8882, "zombae", "Zombetter");
-
-            Core.EquipClass(ClassType.Solo);
-            // 8883 The Ultimate Ghoul Fiend
-            Story.KillQuest(8883, "zombae", "Ghoul Fiend");
+            Core.EnsureAccept(8894);
+            Core.KillMonster("spacepwny", "Enter", "Spawn", "Zom-Bay", "Zom-Bay Defeated", 10);
+            Core.EnsureComplete(8894);
         }
-        public void Mermaidsushi()
+
+        // 8895 Foal of (Thorough) Dread
+        if (!Story.QuestProgression(8895))
         {
-            if (Core.isCompletedBefore(8892))
-                return;
-
-            Core.EquipClass(ClassType.Farm);
-            // 8884 S'KARIN WANT MOGLIN POPPERS,
-            Story.KillQuest(8884, "mermaidsushi", "Undead Moglin");
-
-            // 8885 S'KARIN WANT HAMSTEAK,
-            Story.KillQuest(8885, "mermaidsushi", "Haunted Hamster");
-
-            // 8886 S'KARIN WANT A SKELLO MOLD,
-            Story.KillQuest(8886, "mermaidsushi", "SkeleKitten");
-
-            // 8887 S'KARIN WANT OFFAL BIRD FOOD,
-            Story.KillQuest(8887, "mermaidsushi", "Undead Turkey");
-
-            Core.EquipClass(ClassType.Solo);
-            // 8888 S'KARIN WANT WINGS,
-            Story.KillQuest(8888, "mermaidsushi", "Dedbull");
-
-            // 8889 S'KARIN WANT MERMAID SUSHI 
-            Story.MapItemQuest(8889, "mermaidsushi", 10719);
-
-            // 8890 Mer-Angel Fish Food?!
-            Story.KillQuest(8890, "mermaidsushi", "Necro Minion");
-
-            // 8891 S'KARIN NO WANT GO VIRAL
-            Story.KillQuest(8891, "mermaidsushi", "Customer S'karin");
-
-            // 8892 Gore-Made for This
-            Story.KillQuest(8892, "mermaidsushi", "Die Fieri");
+            Core.EnsureAccept(8895);
+            Core.KillMonster("spacepwny", "r2", "Left", "Thoroughdred", "Thoroughdred Defeated", 10);
+            Core.EnsureComplete(8895);
         }
-        public void FREE500ACSPLEASE()
+
+        // 8896 Create a Stable Base
+        if (!Story.QuestProgression(8896))
         {
-            if (Core.isCompletedBefore(8893))
-                return;
-
-            Bot.Options.RestPackets = false;
-            Bot.Handlers.Remove("AFK Handler");
-
-            // 8893 AFK Quest
-            if (!Story.QuestProgression(8893))
-            {
-                Core.Join("afkquest");
-                Bot.Send.Packet("%xt%zm%afk%0%false%");
-                Core.Logger($"**DO NOT CLICK THE GAME SCREEN** this Will Take ~5minutes, Go touch some grass 👍");
-                Bot.Sleep(360000);
-                Core.Logger("Game Complete. You're Welcome for the Acs");
-            }
+            Core.EnsureAccept(8896);
+            Core.KillMonster("spacepwny", "r2", "Left", "NecroPrancer", "NecroPrancer Defeated", 10);
+            Core.EnsureComplete(8896);
         }
-        public void Spacepwny()
+
+        // 8897 Bonies & Bonies & Bonies
+        if (!Story.QuestProgression(8897))
         {
-            if (Core.isCompletedBefore(8898))
-                return;
-
-            Bot.Options.RestPackets = true;
-
-            Core.EquipClass(ClassType.Farm);
-            // 8894 Plague of Zom-Bays
-            if (!Story.QuestProgression(8894))
-            {
-                Core.EnsureAccept(8894);
-                Core.KillMonster("spacepwny", "Enter", "Spawn", "Zom-Bay", "Zom-Bay Defeated", 10);
-                Core.EnsureComplete(8894);
-            }
-
-            // 8895 Foal of (Thorough) Dread
-            if (!Story.QuestProgression(8895))
-            {
-                Core.EnsureAccept(8895);
-                Core.KillMonster("spacepwny", "r2", "Left", "Thoroughdred", "Thoroughdred Defeated", 10);
-                Core.EnsureComplete(8895);
-            }
-
-            // 8896 Create a Stable Base
-            if (!Story.QuestProgression(8896))
-            {
-                Core.EnsureAccept(8896);
-                Core.KillMonster("spacepwny", "r2", "Left", "NecroPrancer", "NecroPrancer Defeated", 10);
-                Core.EnsureComplete(8896);
-            }
-
-            // 8897 Bonies & Bonies & Bonies
-            if (!Story.QuestProgression(8897))
-            {
-                Core.EnsureAccept(8897);
-                Core.KillMonster("spacepwny", "r3", "Left", "*", "Mare Carnage", 100);
-                Core.EnsureComplete(8897);
-            }
-
-            Core.EquipClass(ClassType.Solo);
-            // 8898 Defeat Mr DED
-            Story.KillQuest(8898, "spacepwny", "Mr DED");
+            Core.EnsureAccept(8897);
+            Core.KillMonster("spacepwny", "r3", "Left", "*", "Mare Carnage", 100);
+            Core.EnsureComplete(8897);
         }
-        public void Deathofgames()
-        {
-            if (Core.isCompletedBefore(8924))
-                return;
 
-            Story.PreLoad(this);
+        Core.EquipClass(ClassType.Solo);
+        // 8898 Defeat Mr DED
+        Story.KillQuest(8898, "spacepwny", "Mr DED");
+    }
+    public void Deathofgames()
+    {
+        if (Core.isCompletedBefore(8924))
+            return;
 
-            //Dungeons & DOOMFights 8899
-            Story.KillQuest(8899, "deathofgames", new[] { "8-Bit Skelly", "8-Bit Sepulchure" });
+        Story.PreLoad(this);
 
-            //AQ3Destruction 8900
-            Story.KillQuest(8900, "deathofgames", new[] { "3D Flying Eye", "Clawg", "Trolluk" });
+        //Dungeons & DOOMFights 8899
+        Story.KillQuest(8899, "deathofgames", new[] { "8-Bit Skelly", "8-Bit Sepulchure" });
 
-            //OverSoul Under Attack 8901
-            Story.KillQuest(8901, "deathofgames", new[] { "Vampire Knight", "Black Dragon" });
+        //AQ3Destruction 8900
+        Story.KillQuest(8900, "deathofgames", new[] { "3D Flying Eye", "Clawg", "Trolluk" });
 
-            //HeroSmashed 8902
-            Story.KillQuest(8902, "deathofgames", new[] { "Rider", "Blaster Master", "Super Death" });
+        //OverSoul Under Attack 8901
+        Story.KillQuest(8901, "deathofgames", new[] { "Vampire Knight", "Black Dragon" });
 
-            //EpicDuel vs DoG 8907
-            Story.KillQuest(8907, "deathofgames", new[] { "Cyber Hunter", "God of War" });
+        //HeroSmashed 8902
+        Story.KillQuest(8902, "deathofgames", new[] { "Rider", "Blaster Master", "Super Death" });
 
-            //AQWorlds At Risk 8920
-            Story.KillQuest(8920, "deathofgames", new[] { "Skeletal Fire Mage", "Drakath" });
+        //EpicDuel vs DoG 8907
+        Story.KillQuest(8907, "deathofgames", new[] { "Cyber Hunter", "God of War" });
 
-            //MechQuest For Glory 8921
-            Story.KillQuest(8921, "deathofgames", new[] { "Newbatron Prime", "ShadowScythe Mecha", "SkullCrusher Mecha" });
+        //AQWorlds At Risk 8920
+        Story.KillQuest(8920, "deathofgames", new[] { "Skeletal Fire Mage", "Drakath" });
 
-            //DragonFables &amp; Lore 8922
-            Story.KillQuest(8922, "deathofgames", new[] { "Fire Elemental", "Xan", "Titan Fluffy" });
+        //MechQuest For Glory 8921
+        Story.KillQuest(8921, "deathofgames", new[] { "Newbatron Prime", "ShadowScythe Mecha", "SkullCrusher Mecha" });
 
-            //AdventureQuest for Victory 8923
-            Story.KillQuest(8923, "deathofgames", new[] { "Moglin Ghost", "Halenro the Paladin", "Mysterious Stranger" });
+        //DragonFables &amp; Lore 8922
+        Story.KillQuest(8922, "deathofgames", new[] { "Fire Elemental", "Xan", "Titan Fluffy" });
 
-            //Battle On... FOREVER! 8924
-            Story.KillQuest(8924, "deathofgames", "Death of Games");
-        }
-    
+        //AdventureQuest for Victory 8923
+        Story.KillQuest(8923, "deathofgames", new[] { "Moglin Ghost", "Halenro the Paladin", "Mysterious Stranger" });
+
+        //Battle On... FOREVER! 8924
+        Story.KillQuest(8924, "deathofgames", "Death of Games");
+    }
+
 }

--- a/Seasonal/AqwBirthday/AspiringNecromancer.cs
+++ b/Seasonal/AqwBirthday/AspiringNecromancer.cs
@@ -19,7 +19,7 @@ public class AspiringNecromancer
 
     public void Example()
     {
-        
+
         string[] Quest1Rewards = (Core.EnsureLoad(7751).Rewards.Select(i => i.Name).ToArray());
         string[] Quest2Rewards = (Core.EnsureLoad(7752).Rewards.Select(i => i.Name).ToArray());
         string[] Quest3Rewards = (Core.EnsureLoad(7753).Rewards.Select(i => i.Name).ToArray());
@@ -37,7 +37,7 @@ public class AspiringNecromancer
         Core.JumpWait();
         Core.CancelRegisteredQuests();
         Core.ToBank(AllRewards);
-        
+
         //Like No One Ever Was 7752
         Core.RegisterQuests(7752);
         while (!Bot.ShouldExit && !Core.CheckInventory(Quest2Rewards, toInv: false))
@@ -46,7 +46,7 @@ public class AspiringNecromancer
         Core.CancelRegisteredQuests();
         Core.ToBank(AllRewards);
 
-        
+
         Bot.Quests.UpdateQuest(2060);
         Bot.Quests.UpdateQuest(3019);
         //To Raise Them is my Real Quest 7753

--- a/Seasonal/AqwBirthday/AspiringNecromancerMerge.cs
+++ b/Seasonal/AqwBirthday/AspiringNecromancerMerge.cs
@@ -32,13 +32,13 @@ public class AspiringNecromancerMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.isSeasonalMapActive("birthday"))
             return;
 
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("battleontown", 1924, findIngredients);
+        Adv.StartBuyAllMerge("battleontown", 1924, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/AqwBirthday/BeleensPartyPresentsMerge.cs
+++ b/Seasonal/AqwBirthday/BeleensPartyPresentsMerge.cs
@@ -32,12 +32,12 @@ public class BeleensPartyPresentsMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.isSeasonalMapActive("yulgar20"))
             return;
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("yulgar20", 2177, findIngredients);
+        Adv.StartBuyAllMerge("yulgar20", 2177, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/AqwBirthday/MermaidSushiMerge.cs
+++ b/Seasonal/AqwBirthday/MermaidSushiMerge.cs
@@ -32,11 +32,11 @@ public class MermaidSushiMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         Bot.Quests.UpdateQuest(8892);
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("mermaidsushi", 2178, findIngredients);
+        Adv.StartBuyAllMerge("mermaidsushi", 2178, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/AqwBirthday/ZorbaksMerge.cs
+++ b/Seasonal/AqwBirthday/ZorbaksMerge.cs
@@ -32,13 +32,13 @@ public class ZorbaksMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.isSeasonalMapActive("birthday"))
             return;
-            
+
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("battleon", 1640, findIngredients);
+        Adv.StartBuyAllMerge("battleon", 1640, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/August/Kala.cs
+++ b/Seasonal/August/Kala.cs
@@ -23,7 +23,7 @@ public class KalaSeasonal
     {
         if (!Core.isSeasonalMapActive("kala"))
             return;
-            
+
         Ran.StoryLine();
 
         if (Core.isCompletedBefore(8214))

--- a/Seasonal/BlackFriday/EbonyDragonBladeOfNulgath.cs
+++ b/Seasonal/BlackFriday/EbonyDragonBladeOfNulgath.cs
@@ -23,16 +23,16 @@ public class EbonyDragonBladeofNulgath
         if (Core.CheckInventory("Ebony DragonBlade of Nulgath"))
             return;
 
-        if(!Core.IsMember && !Core.CheckInventory("DragonBlade of Nulgath"))
+        if (!Core.IsMember && !Core.CheckInventory("DragonBlade of Nulgath"))
         {
             Core.Logger("You must be a member to farm DragonBlade of Nulgath! (Required to merge Ebony DBoN)");
             return;
         }
-        
-        Core.BankingBlackList.AddRange(new[] {"DragonBlade of Nulgath", "Diamond of Nulgath", "Ebony DragonBlade of Nulgath"});
-        if(!Core.CheckInventory("Diamond of Nulgath", 100))
+
+        Core.BankingBlackList.AddRange(new[] { "DragonBlade of Nulgath", "Diamond of Nulgath", "Ebony DragonBlade of Nulgath" });
+        if (!Core.CheckInventory("Diamond of Nulgath", 100))
             Nation.FarmDiamondofNulgath(100);
-        if(!Core.CheckInventory("DragonBlade of Nulgath"))
+        if (!Core.CheckInventory("DragonBlade of Nulgath"))
             DBoN.GetDragonBlade();
         Core.BuyItem("evilwarnul", 456, "Ebony DragonBlade of Nulgath");
     }

--- a/Seasonal/BlackFriday/ShadowDragonShinobiMerge.cs
+++ b/Seasonal/BlackFriday/ShadowDragonShinobiMerge.cs
@@ -32,7 +32,7 @@ public class ShadowDragonShinobiMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
         if (!Core.isSeasonalMapActive("blackfridaywar"))
@@ -41,7 +41,7 @@ public class ShadowDragonShinobiMerge
             return;
         }
 
-        Adv.StartBuyAllMerge("blackfridaywar", 756, findIngredients);
+        Adv.StartBuyAllMerge("blackfridaywar", 756, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/BlackFriday/TechnocasterMerge.cs
+++ b/Seasonal/BlackFriday/TechnocasterMerge.cs
@@ -22,7 +22,7 @@ public class TechnocasterMerge
 
     public void ScriptMain(IScriptInterface Bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Purified Energy Core", "Seraphic Steel Plate"});
+        Core.BankingBlackList.AddRange(new[] { "Purified Energy Core", "Seraphic Steel Plate" });
         Core.AddDrop("Purified Energy Core", "Seraphic Steel Plate");
         Core.SetOptions();
 
@@ -31,10 +31,10 @@ public class TechnocasterMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("technospace", 1802, findIngredients);
+        Adv.StartBuyAllMerge("technospace", 1802, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()
@@ -62,7 +62,7 @@ public class TechnocasterMerge
                     Core.RegisterQuests(7236);
                     while (!Bot.ShouldExit && !Core.CheckInventory(req.Name, quant))
                     {
-                        Core.HuntMonster("technospace", "Technocaster Rogue", "Energy Core", log:false);
+                        Core.HuntMonster("technospace", "Technocaster Rogue", "Energy Core", log: false);
                         Bot.Wait.ForPickup(req.Name);
                     }
                     Core.CancelRegisteredQuests();
@@ -74,7 +74,7 @@ public class TechnocasterMerge
                     Core.RegisterQuests(7235);
                     while (!Bot.ShouldExit && !Core.CheckInventory(req.Name, quant))
                     {
-                        Core.HuntMonster("technospace", "Technowolf", "Seraphic Steel", 5, log:false);
+                        Core.HuntMonster("technospace", "Technowolf", "Seraphic Steel", 5, log: false);
                         Bot.Wait.ForPickup(req.Name);
                     }
                     Core.CancelRegisteredQuests();

--- a/Seasonal/Frostvale/FrostvalBarbarian.cs
+++ b/Seasonal/Frostvale/FrostvalBarbarian.cs
@@ -29,7 +29,7 @@ public class FrostvalBarbarian
 
     public void GetFB(bool rankUpClass = true)
     {
-        
+
         if (Core.CheckInventory("Frostval Barbarian"))
             return;
         if (!Core.isSeasonalMapActive("frostvale"))

--- a/Seasonal/Frostvale/FrostvaleBadges.cs
+++ b/Seasonal/Frostvale/FrostvaleBadges.cs
@@ -25,13 +25,13 @@ public class FrostvaleBadges
             Core.Logger($"Already have the Frostvale badges");
             return;
         }
-        
+
         if (!Core.HasWebBadge(badge1))
             Core.Logger("World Savior: Reward from; \"Face Kezeroth\" Quest.");
-        
+
         if (!Core.HasWebBadge(badge2))
             Core.Logger("Frost Defanged: Reward from; \"Defeat Frostfang (Evil/Good)\" ");
-        
+
         Core.Logger("Doing Frostvale story for badges");
         Frostvale.DoAll();
     }

--- a/Seasonal/Frostvale/FrozenSoulMerge.cs
+++ b/Seasonal/Frostvale/FrozenSoulMerge.cs
@@ -20,7 +20,7 @@ public class FrozenSoulMerge
 
     public void ScriptMain(IScriptInterface Bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Hammered Ice", "Frosted Heart", "Frozen Soul", "Frozen Rune of Kheimon", "Poleaxe of Kheimon", "Elegant Frostvale Suit", "Cheery Frostvale Hat + Locks", "Elegant Frostval Wrap", "Cheery Frostvale Hat", "Ruby Frostval Cane "});
+        Core.BankingBlackList.AddRange(new[] { "Hammered Ice", "Frosted Heart", "Frozen Soul", "Frozen Rune of Kheimon", "Poleaxe of Kheimon", "Elegant Frostvale Suit", "Cheery Frostvale Hat + Locks", "Elegant Frostval Wrap", "Cheery Frostvale Hat", "Ruby Frostval Cane " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -28,10 +28,10 @@ public class FrozenSoulMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("frozensoul", 1815, findIngredients);
+        Adv.StartBuyAllMerge("frozensoul", 1815, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/Frostvale/HelsgroveMerge.cs
+++ b/Seasonal/Frostvale/HelsgroveMerge.cs
@@ -22,7 +22,7 @@ public class HelsgroveMerge
 
     public void ScriptMain(IScriptInterface Bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Golden Branch", "Frostval Treat", "Hazel Switch", "Helsgrove Guardian Scarf", "Chibi GroveRider's Locks", "Chibi GroveRider's Locks + Bridle "});
+        Core.BankingBlackList.AddRange(new[] { "Golden Branch", "Frostval Treat", "Hazel Switch", "Helsgrove Guardian Scarf", "Chibi GroveRider's Locks", "Chibi GroveRider's Locks + Bridle " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -30,10 +30,10 @@ public class HelsgroveMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("helsgrove", 2076, findIngredients);
+        Adv.StartBuyAllMerge("helsgrove", 2076, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/Frostvale/HuntressMerge.cs
+++ b/Seasonal/Frostvale/HuntressMerge.cs
@@ -30,10 +30,10 @@ public class HuntressMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("otziwar", 2088, findIngredients);
+        Adv.StartBuyAllMerge("otziwar", 2088, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/Frostvale/SnowviewMerge.cs
+++ b/Seasonal/Frostvale/SnowviewMerge.cs
@@ -25,7 +25,7 @@ public class SnowviewMerge
 
     public void ScriptMain(IScriptInterface Bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Fire Starting Kit "});
+        Core.BankingBlackList.AddRange(new[] { "Fire Starting Kit " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -33,12 +33,12 @@ public class SnowviewMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         Frostvale.Snowview();
-        
+
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("snowview", 2195, findIngredients);
+        Adv.StartBuyAllMerge("snowview", 2195, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/HarvestDay/CoreHarvestDay.cs
+++ b/Seasonal/HarvestDay/CoreHarvestDay.cs
@@ -38,7 +38,8 @@ public class CoreHarvestDay
             EpilTakeOver();
             BirdsWithHarms();
             EbilCorpHQ();
-        } else
+        }
+        else
         {
             EbilCorpHQ();
         }

--- a/Seasonal/HarvestDay/MergeShops/EbilCorpCafeMerge.cs
+++ b/Seasonal/HarvestDay/MergeShops/EbilCorpCafeMerge.cs
@@ -33,13 +33,13 @@ public class EbilCorpCafeMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.isSeasonalMapActive("ebiltakeover"))
             return;
         HD.EpilTakeOver();
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("ebiltakeover", 2190, findIngredients);
+        Adv.StartBuyAllMerge("ebiltakeover", 2190, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/HarvestDay/MergeShops/EbilCorpHQMerge.cs
+++ b/Seasonal/HarvestDay/MergeShops/EbilCorpHQMerge.cs
@@ -31,13 +31,13 @@ public class EbilHQMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         HarvestDay.EbilCorpHQ();
-        
+
         Core.AddDrop(NeededItems);
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("ebilcorphq", 2067, findIngredients);
+        Adv.StartBuyAllMerge("ebilcorphq", 2067, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/HarvestDay/MergeShops/HarvestDayParadeMerge.cs
+++ b/Seasonal/HarvestDay/MergeShops/HarvestDayParadeMerge.cs
@@ -24,7 +24,7 @@ public class HarvestDayParadeMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Pink Balloon Scrap", "Green Balloon Scrap", "Red Balloon Scrap "});
+        Core.BankingBlackList.AddRange(new[] { "Pink Balloon Scrap", "Green Balloon Scrap", "Red Balloon Scrap " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -32,12 +32,12 @@ public class HarvestDayParadeMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.isSeasonalMapActive("float"))
             return;
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("float", 234, findIngredients);
+        Adv.StartBuyAllMerge("float", 234, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/HarvestDay/MergeShops/HarvestMerge.cs
+++ b/Seasonal/HarvestDay/MergeShops/HarvestMerge.cs
@@ -33,10 +33,10 @@ public class HarvestMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("feast", 2181, findIngredients);
+        Adv.StartBuyAllMerge("feast", 2181, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/HarvestDay/MergeShops/NightmareHarvestMerge.cs
+++ b/Seasonal/HarvestDay/MergeShops/NightmareHarvestMerge.cs
@@ -32,12 +32,12 @@ public class NightmareHarvestMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.isSeasonalMapActive("gothicdream"))
             return;
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("gothicdream", 1939, findIngredients);
+        Adv.StartBuyAllMerge("gothicdream", 1939, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/HarvestDay/MergeShops/NightmareHarvestWarMerge.cs
+++ b/Seasonal/HarvestDay/MergeShops/NightmareHarvestWarMerge.cs
@@ -35,12 +35,12 @@ public class NightmareHarvestWarMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.isSeasonalMapActive("nightmarewar"))
             return;
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("nightmarewar", 1941, findIngredients);
+        Adv.StartBuyAllMerge("nightmarewar", 1941, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/Mogloween/MergeShops/CandiedCostumesMerge.cs
+++ b/Seasonal/Mogloween/MergeShops/CandiedCostumesMerge.cs
@@ -41,12 +41,12 @@ public class CandiedCostumesMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.isSeasonalMapActive("mogloween"))
             return;
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("candyshop", 1761, findIngredients);
+        Adv.StartBuyAllMerge("candyshop", 1761, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/Mogloween/MergeShops/ChromaCandyMerge.cs
+++ b/Seasonal/Mogloween/MergeShops/ChromaCandyMerge.cs
@@ -24,7 +24,7 @@ public class ChromaCandyMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Orange Dye", "Green Dye", "Yellow Dye", "Black Dye", "Purple Dye", "Pink Dye "});
+        Core.BankingBlackList.AddRange(new[] { "Orange Dye", "Green Dye", "Yellow Dye", "Black Dye", "Purple Dye", "Pink Dye " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -32,12 +32,12 @@ public class ChromaCandyMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.isSeasonalMapActive("mogloween"))
             return;
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("chromafection", 1622, findIngredients);
+        Adv.StartBuyAllMerge("chromafection", 1622, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()
@@ -73,7 +73,7 @@ public class ChromaCandyMerge
                         Core.HuntMonster("chromafection", "Chromafection", "Candy Dye", 3);
                         Core.EnsureComplete(6538, req.ID);
                     }
-                    break;  
+                    break;
 
             }
         }

--- a/Seasonal/Mogloween/MergeShops/CrescentMerge.cs
+++ b/Seasonal/Mogloween/MergeShops/CrescentMerge.cs
@@ -32,12 +32,12 @@ public class CrescentMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.isSeasonalMapActive("crescentmoon"))
             return;
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("crescentmoon", 2172, findIngredients);
+        Adv.StartBuyAllMerge("crescentmoon", 2172, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/Mogloween/MergeShops/Mog-GLOW-weenMerge.cs
+++ b/Seasonal/Mogloween/MergeShops/Mog-GLOW-weenMerge.cs
@@ -32,12 +32,12 @@ public class MogGLOWweenMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.isSeasonalMapActive("mogloween"))
             return;
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("franken", 770, findIngredients);
+        Adv.StartBuyAllMerge("franken", 770, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/Mogloween/MergeShops/MogloweenSeasonalMerge.cs
+++ b/Seasonal/Mogloween/MergeShops/MogloweenSeasonalMerge.cs
@@ -36,12 +36,12 @@ public class MogloweenSeasonalMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.isSeasonalMapActive("mogloween"))
             return;
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("mogloween", 223, findIngredients);
+        Adv.StartBuyAllMerge("mogloween", 223, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/Mogloween/MergeShops/TricktownMerge.cs
+++ b/Seasonal/Mogloween/MergeShops/TricktownMerge.cs
@@ -26,7 +26,7 @@ public class TricktownMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Treats", "Ghastly Gummy "});
+        Core.BankingBlackList.AddRange(new[] { "Treats", "Ghastly Gummy " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -34,14 +34,14 @@ public class TricktownMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.isSeasonalMapActive("tricktown"))
             return;
         CoreMogloween.TrickTown();
-        
+
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("tricktown", 2179, findIngredients);
+        Adv.StartBuyAllMerge("tricktown", 2179, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/Mogloween/MergeShops/VampireLordMerge.cs
+++ b/Seasonal/Mogloween/MergeShops/VampireLordMerge.cs
@@ -24,7 +24,7 @@ public class VampireLordMerge
 
     public void ScriptMain(IScriptInterface bot)
     {
-        Core.BankingBlackList.AddRange(new[] { "Blood Moon Token "});
+        Core.BankingBlackList.AddRange(new[] { "Blood Moon Token " });
         Core.SetOptions();
 
         BuyAllMerge();
@@ -32,12 +32,12 @@ public class VampireLordMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.isSeasonalMapActive("mogloween"))
             return;
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("mogloween", 1477, findIngredients);
+        Adv.StartBuyAllMerge("mogloween", 1477, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/StaffBirthdays/DageTheEvil/DarkWarLegionMerge.cs
+++ b/Seasonal/StaffBirthdays/DageTheEvil/DarkWarLegionMerge.cs
@@ -30,13 +30,13 @@ public class DarkWarLegionMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
         if (!Core.isSeasonalMapActive("darkwarlegion"))
             return;
 
-        Adv.StartBuyAllMerge("darkwarlegion", 2122, findIngredients);
+        Adv.StartBuyAllMerge("darkwarlegion", 2122, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/StaffBirthdays/DageTheEvil/DarkWarNationMerge.cs
+++ b/Seasonal/StaffBirthdays/DageTheEvil/DarkWarNationMerge.cs
@@ -32,13 +32,13 @@ public class DarkWarNationMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
         if (!Core.isSeasonalMapActive("darkwarnation"))
             return;
 
-        Adv.StartBuyAllMerge("darkwarnation", 2121, findIngredients);
+        Adv.StartBuyAllMerge("darkwarnation", 2121, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/StaffBirthdays/DageTheEvil/DarkwarlegionWarChestMerge.cs
+++ b/Seasonal/StaffBirthdays/DageTheEvil/DarkwarlegionWarChestMerge.cs
@@ -33,13 +33,13 @@ public class DarkwarlegionWarChestMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        if(!Core.isSeasonalMapActive("darkwarlegion"))
-        return;
-        
-        Adv.StartBuyAllMerge("darkwarlegion", 2124, findIngredients);
+        if (!Core.isSeasonalMapActive("darkwarlegion"))
+            return;
+
+        Adv.StartBuyAllMerge("darkwarlegion", 2124, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/StaffBirthdays/DageTheEvil/NationWarChestMerge.cs
+++ b/Seasonal/StaffBirthdays/DageTheEvil/NationWarChestMerge.cs
@@ -34,13 +34,13 @@ public class NationWarChestMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
         if (!Core.isSeasonalMapActive("darkwarnation"))
             return;
 
-        Adv.StartBuyAllMerge("darkwarnation", 2123, findIngredients);
+        Adv.StartBuyAllMerge("darkwarnation", 2123, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/StarFestival/ShorinzanMerge.cs
+++ b/Seasonal/StarFestival/ShorinzanMerge.cs
@@ -33,10 +33,10 @@ public class ShorinzanMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("starfest", 2148, findIngredients);
+        Adv.StartBuyAllMerge("starfest", 2148, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/SummerBreak/BlazingBeachMerge.cs
+++ b/Seasonal/SummerBreak/BlazingBeachMerge.cs
@@ -36,13 +36,13 @@ public class BlazingBeachMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.isSeasonalMapActive("blazingbeach"))
             return;
 
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("blazingbeach", 2138, findIngredients);
+        Adv.StartBuyAllMerge("blazingbeach", 2138, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/SummerBreak/CoralBeachMerge.cs
+++ b/Seasonal/SummerBreak/CoralBeachMerge.cs
@@ -31,13 +31,13 @@ public class CoralBeachMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.isSeasonalMapActive("coralbeach"))
             return;
 
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("coralbeach", 79, findIngredients);
+        Adv.StartBuyAllMerge("coralbeach", 79, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/SummerBreak/ExtraCreditACItems.cs
+++ b/Seasonal/SummerBreak/ExtraCreditACItems.cs
@@ -49,7 +49,7 @@ public class ExtraCreditAC
     {
         if (!Core.isSeasonalMapActive("extracredit"))
             return;
-            
+
         if (Core.CheckInventory(Dogear) && Core.CheckInventory(Bully) && Core.CheckInventory(Locker))
             return;
 

--- a/Seasonal/SummerBreak/LunaCoveMerge.cs
+++ b/Seasonal/SummerBreak/LunaCoveMerge.cs
@@ -31,13 +31,13 @@ public class LunaCoveMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.isSeasonalMapActive("lunacove"))
             return;
-            
+
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("lunacove", 32, findIngredients);
+        Adv.StartBuyAllMerge("lunacove", 32, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/SummerBreak/SummerBreakMerge.cs
+++ b/Seasonal/SummerBreak/SummerBreakMerge.cs
@@ -36,13 +36,13 @@ public class SummerBreakMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         if (!Core.isSeasonalMapActive("summerbreak"))
             return;
-            
+
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("summerbreak", 2155, findIngredients);
+        Adv.StartBuyAllMerge("summerbreak", 2155, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/SummerBreak/SweetSummerTreats.cs
+++ b/Seasonal/SummerBreak/SweetSummerTreats.cs
@@ -19,7 +19,7 @@ public class SweetSummerTreats
     {
         if (!Core.isSeasonalMapActive("summerbreak"))
             return;
-            
+
         string[] rewards = { "Sunflower Outfit", "SunFlower Locks", "Sunflower Hair" };
         if (Core.CheckInventory(rewards, toInv: false))
             return;

--- a/Seasonal/TalkLikeaPirateDay/AluteaNursery.cs
+++ b/Seasonal/TalkLikeaPirateDay/AluteaNursery.cs
@@ -25,7 +25,7 @@ public class AluteaNursery
     {
         if (!Core.isSeasonalMapActive("AluteaNursery"))
             return;
-            
+
         AluteaNurseryStory();
         AluteaNurseryRewards();
     }

--- a/Seasonal/TalkLikeaPirateDay/DragonCapitalStory.cs
+++ b/Seasonal/TalkLikeaPirateDay/DragonCapitalStory.cs
@@ -23,7 +23,7 @@ public class DragonCapitalStory
     {
         if (!Core.isSeasonalMapActive("dragoncapital"))
             return;
-            
+
         if (Core.isCompletedBefore(8287))
             return;
 

--- a/Seasonal/TalkLikeaPirateDay/MergeShops/AluteaNurseryMerge.cs
+++ b/Seasonal/TalkLikeaPirateDay/MergeShops/AluteaNurseryMerge.cs
@@ -35,11 +35,11 @@ public class AluteaNurseryMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         AN.DoAll();
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("aluteanursery", 2168, findIngredients);
+        Adv.StartBuyAllMerge("aluteanursery", 2168, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()
@@ -92,7 +92,7 @@ public class AluteaNurseryMerge
                 case "DeepSea Star Pirate's Light Guns":
                 case "DeepSea Smol Wave":
                     Core.EquipClass(ClassType.Solo);
-                    Core.HuntMonster("aluteanursery", "Last Alutian", req.Name, isTemp:false);
+                    Core.HuntMonster("aluteanursery", "Last Alutian", req.Name, isTemp: false);
                     break;
 
             }

--- a/Seasonal/TalkLikeaPirateDay/MergeShops/BlazeBeardMerge.cs
+++ b/Seasonal/TalkLikeaPirateDay/MergeShops/BlazeBeardMerge.cs
@@ -34,10 +34,10 @@ public class BlazeBeardMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("blazebeard", 108, findIngredients);
+        Adv.StartBuyAllMerge("blazebeard", 108, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/TalkLikeaPirateDay/MergeShops/DragonCapitalMerge.cs
+++ b/Seasonal/TalkLikeaPirateDay/MergeShops/DragonCapitalMerge.cs
@@ -35,11 +35,11 @@ public class DragonCapitalMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         DCS.DragonCapital();
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("dragoncapital", 2053, findIngredients);
+        Adv.StartBuyAllMerge("dragoncapital", 2053, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Seasonal/TalkLikeaPirateDay/MergeShops/DragonPirateMerge.cs
+++ b/Seasonal/TalkLikeaPirateDay/MergeShops/DragonPirateMerge.cs
@@ -34,11 +34,11 @@ public class DragonPirateMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         DP.DragonPirate();
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("dragonpirate", 2048, findIngredients);
+        Adv.StartBuyAllMerge("dragonpirate", 2048, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()
@@ -89,9 +89,9 @@ public class DragonPirateMerge
                     break;
 
                 case "Lightning Pirate":
-                Core.EquipClass(ClassType.Solo);
-                Core.HuntMonster("dragonpirate", "Scalebeard", req.Name);
-                break;
+                    Core.EquipClass(ClassType.Solo);
+                    Core.HuntMonster("dragonpirate", "Scalebeard", req.Name);
+                    break;
             }
         }
     }

--- a/Seasonal/TalkLikeaPirateDay/MergeShops/LowTideMerge.cs
+++ b/Seasonal/TalkLikeaPirateDay/MergeShops/LowTideMerge.cs
@@ -34,11 +34,11 @@ public class LowTideMerge
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         LT.Storyline();
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("lowtide", 2166, findIngredients);
+        Adv.StartBuyAllMerge("lowtide", 2166, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Skills/AdvancedSkills.txt
+++ b/Skills/AdvancedSkills.txt
@@ -166,6 +166,7 @@ Base = Mystical Dark Caster = 1 | 2 | 3 | 4 = Use if Available
 Base = Naval Commander = 3WW10000 | 4 | 2 | 1 = 250
 Base = Nechronomancer = 4 H<40S | 3 | 1 | 2 = Use if Available
 Base = Necrotic Chronomancer = 4 H<40S | 3 | 1 | 2 = Use if Available
+Base = Necromancer = 1 | 2 | 3 M<25S H<30S | 4 = Use if Available
 Base = Ninja = 1 | 2 | 3 | 4 = Use if Available
 Base = Ninja Warrior = 1 | 2 | 3 | 4 = Use if Available
 Base = Northlands Monk = 1 | 2 | 3 | 4 = Use if Available

--- a/Story/0AllStories.cs
+++ b/Story/0AllStories.cs
@@ -623,7 +623,7 @@ public class AllStories
         DoomVaultA.StoryLine();
         Core.Logger($"Story: Doom Vault B - Complete");
         DoomVaultB.StoryLine();
-        
+
         Core.Logger($"Story: Doom Vault A - Complete");
 
         Downward.StoryLine();

--- a/Story/7DeadlyDragons/Core7DD.cs
+++ b/Story/7DeadlyDragons/Core7DD.cs
@@ -137,7 +137,7 @@ public class Core7DD
             return;
 
         Core.Logger("Hunting the Ice Dragon of Greed!");
-            
+
         Story.PreLoad(this);
 
         // Looting is for Sneevils 5934

--- a/Story/AriaPet[MEM].cs
+++ b/Story/AriaPet[MEM].cs
@@ -22,7 +22,7 @@ public class AriaPet
             Core.Logger("Aria Pet Storyline Is Member Only. Skipping this Script");
             return;
         }
-            
+
         if (Core.isCompletedBefore(46))
             return;
 

--- a/Story/Borgars.cs
+++ b/Story/Borgars.cs
@@ -27,19 +27,19 @@ public class Borgars
         // Beef Up 7510
         Core.AddDrop("Slice of Cake");
         Story.KillQuest(7510, "extinction", new[] { "Lard", "Freezer Drone" });
-       
+
         // Creamy! 7511
         Story.KillQuest(7511, "battlefowl", "Chickencow", false);
-      
+
         // Sacchar-Imp 7512
         Story.KillQuest(7512, "freakitiki", "Sugar Imp", false);
-      
+
         // Salty Balboa 7513
         Story.KillQuest(7513, "stalagbite", "Balboa");
-       
+
         // Filet o' Fishwing 7514
         Story.KillQuest(7514, "pirates", "Fishwing", false);
-      
+
         // A Potion Master 7515
         Story.MapItemQuest(7515, "arcangrove", 7370);
 

--- a/Story/Concert[MEM].cs
+++ b/Story/Concert[MEM].cs
@@ -76,7 +76,7 @@ public class Concert
     {
         if (Core.isCompletedBefore(1035))
             return;
-        
+
         //Death Be Not Pround 1030
         Story.MapItemQuest(1030, "feardeath", 391);
 

--- a/Story/Cornelis[mem].cs
+++ b/Story/Cornelis[mem].cs
@@ -32,7 +32,7 @@ public class Cornelis
 
         // The Frame Up 1627
         Story.KillQuest(1627, "cornelis", "Gargoyle");
-        
+
         // The Lenscrafter 1628
         if (!Story.QuestProgression(1628))
         {
@@ -40,13 +40,13 @@ public class Cornelis
             Core.BuyItem("yulgar", 366, "The Lens of Cornelis");
             Core.EnsureComplete(1628);
         }
-        
+
         // The Hidden Vault 1629
         Story.MapItemQuest(1629, "cornelis", 858);
-        
+
         // The Guardian 1630
         Story.KillQuest(1630, "cornelis", "Gargantugoyle");
-        
+
         //The Family Jewels 1631
         Story.MapItemQuest(1631, "cornelis", 859);
 

--- a/Story/DeerHunt.cs
+++ b/Story/DeerHunt.cs
@@ -30,11 +30,11 @@ public class DeerHunt
 
         // Deer? 8424
         Story.KillQuest(8424, "deerhunt", "Deer?");
-        
+
         // Comparing Claws 8425
         Story.MapItemQuest(8425, "deerhunt", 9373, 4);
         Story.KillQuest(8425, "deerhunt", new[] { "Scared Wolf", "Frightened Owl" });
-        
+
         // Lair Investigated 8426
         Story.MapItemQuest(8426, "deerhunt", new[] { 9374, 9375 });
 

--- a/Story/ElegyofMadness(Darkon)/CoreAstravia.cs
+++ b/Story/ElegyofMadness(Darkon)/CoreAstravia.cs
@@ -73,8 +73,8 @@ public class CoreAstravia
         if (!Story.QuestProgression(7774))
         {
             Core.EnsureAccept(7774);
-            Core.HuntMonsterMapID("eridani", 22|3, "Rat-Like Creature Slain");
-            Core.HuntMonsterMapID("eridani", 13|24|29, "Bat-Like Creature Slain");
+            Core.HuntMonsterMapID("eridani", 22 | 3, "Rat-Like Creature Slain");
+            Core.HuntMonsterMapID("eridani", 13 | 24 | 29, "Bat-Like Creature Slain");
             Core.HuntMonsterMapID("eridani", 1, "Maggot-Like Creatures Slain", 2);
             Story.MapItemQuest(7774, "eridani", 7784);
         }

--- a/Story/Extinction.cs
+++ b/Story/Extinction.cs
@@ -24,35 +24,35 @@ public class Extinction
 
         Story.PreLoad(this);
 
-    //Chopped HAMM 3855
-    Story.MapItemQuest(3855, "extinction", 2956, 5);
-    Story.KillQuest(3855, "extinction", "Control Panel");
+        //Chopped HAMM 3855
+        Story.MapItemQuest(3855, "extinction", 2956, 5);
+        Story.KillQuest(3855, "extinction", "Control Panel");
 
-    //Bad Dog 3856
-    Story.KillQuest(3856, "extinction", "Cyworg");
+        //Bad Dog 3856
+        Story.KillQuest(3856, "extinction", "Cyworg");
 
-    //Pink Slime Yum! 3857
-    Story.KillQuest(3857, "extinction", new[] { "Pink Slime", "Gelatinous Slime" });
+        //Pink Slime Yum! 3857
+        Story.KillQuest(3857, "extinction", new[] { "Pink Slime", "Gelatinous Slime" });
 
-    //Processed What? 3858
-    Story.MapItemQuest(3858, "extinction", 2957, 5);
+        //Processed What? 3858
+        Story.MapItemQuest(3858, "extinction", 2957, 5);
 
-    //Another Locked Door 3859
-    Story.KillQuest(3859, "extinction", "Slimed Drone");
+        //Another Locked Door 3859
+        Story.KillQuest(3859, "extinction", "Slimed Drone");
 
-    //This Factory is On Fire 3860
-    Story.KillQuest(3860, "extinction", "Freezer Drone");
+        //This Factory is On Fire 3860
+        Story.KillQuest(3860, "extinction", "Freezer Drone");
 
-    //Frozen... Food? 3861
-    Story.MapItemQuest(3861, "extinction", 2958, 5);
+        //Frozen... Food? 3861
+        Story.MapItemQuest(3861, "extinction", 2958, 5);
 
-    //Fight Fire With Flammable Ingredients 3862
-    Story.KillQuest(3862, "extinction", "Lard");
+        //Fight Fire With Flammable Ingredients 3862
+        Story.KillQuest(3862, "extinction", "Lard");
 
-    //The Last Lock 3863
-    Story.KillQuest(3863, "extinction", "Freezer Drone");
+        //The Last Lock 3863
+        Story.KillQuest(3863, "extinction", "Freezer Drone");
 
-    //SN.O.W. Fall 3864
-    Story.KillQuest(3864, "extinction", "SN.O.W.");
+        //SN.O.W. Fall 3864
+        Story.KillQuest(3864, "extinction", "SN.O.W.");
     }
 }

--- a/Story/HuntersMoon.cs
+++ b/Story/HuntersMoon.cs
@@ -18,7 +18,7 @@ public class HuntersMoon
     }
 
     public void StoryLine()
-    {        
+    {
         if (Core.isCompletedBefore(6810))
             return;
 
@@ -32,40 +32,40 @@ public class HuntersMoon
         #region Hunter's Moon
         // Put out the Fire 6700
         Story.KillQuest(6700, "huntersmoon", "Dark Fire");
-        
+
         // The Most Dire of Beasts 6701
         Story.KillQuest(6701, "huntersmoon", "Eclipsed One");
-        
+
         // Find the Elder 6702
         Story.MapItemQuest(6702, "huntersmoon", 6195);
-        
+
         // Send them Home 6703
         Story.MapItemQuest(6703, "huntersmoon", 6194, 6);
-        
+
         // Who are the Blood Moon Clan? 6704
         Story.KillQuest(6704, "huntersmoon", "Blood Moon Hooligan");
-        
+
         // Light the Torches 6705
         Story.KillQuest(6705, "huntersmoon", "Dark Fire");
-        
+
         // Gather the Blood 6706
         Story.KillQuest(6706, "huntersmoon", "Eclipsed One");
-        
+
         // Find the Skull! 6707
         Story.KillQuest(6707, "huntersmoon", "Marchiosas Acolyte");
-        
+
         // Tree of Wisdom 6708
         Story.MapItemQuest(6708, "huntersmoon", 6193);
-        
+
         // Shards of Moonlight 6709
         Story.MapItemQuest(6709, "huntersmoon", 6192, 6);
-        
+
         // Moon-Struck 6710
         Story.KillQuest(6710, "huntersmoon", "Eclipsed One");
-        
+
         // Offer the Skull 6711
         Story.MapItemQuest(6711, "huntersmoon", 6191);
-        
+
         // The Fighting Spirit 6712
         Story.KillQuest(6712, "huntersmoon", "Spirit of Voland");
         #endregion
@@ -73,37 +73,37 @@ public class HuntersMoon
         #region Moon Cursed Lair
         // Moon Crystals 6799
         Story.KillQuest(6799, "mooncursedlair", "Shard of Moonlight");
-        
+
         // Eclipsed Blood 6800
         Story.KillQuest(6800, "mooncursedlair", "Eclipsed One");
-        
+
         // Heart of the Bear 6801
         Story.KillQuest(6801, "mooncursedlair", "Tainted Grizzly");
-        
+
         // Forge of the Moon 6802
         Story.MapItemQuest(6802, "mooncursedlair", 6325);
-        
+
         // Bear-ly Alive 6803
         Story.KillQuest(6803, "mooncursedlair", "Corrupted Bear");
-        
+
         // Cleanse the Filth 6804
         Story.KillQuest(6804, "mooncursedlair", "Corrupted Sludge");
-        
+
         // Search the Cave 6805
         Story.MapItemQuest(6805, "mooncursedlair", 6326);
-        
+
         // Clear the Eclipse 6806
         Story.KillQuest(6806, "mooncursedlair", "Eclipsed One");
-        
+
         // Interrogation 6807
         Story.KillQuest(6807, "mooncursedlair", "Blood Moon Minion");
-        
+
         // Search for Clues 6808
         Story.KillQuest(6808, "mooncursedlair", "Matted Yuck");
-        
+
         // Check the Nest 6809
         Story.MapItemQuest(6809, "mooncursedlair", 6327);
-        
+
         // Defeat Marchosias! 6810
         Story.KillQuest(6810, "mooncursedlair", "Marchosias");
         #endregion

--- a/Story/IsleOfFotia/04Judgement.cs
+++ b/Story/IsleOfFotia/04Judgement.cs
@@ -18,5 +18,5 @@ public class Judgement
 
         Core.SetOptions(false);
     }
-   
+
 }

--- a/Story/Lair.cs
+++ b/Story/Lair.cs
@@ -97,7 +97,7 @@ public class Lair
 
         // Do Not Crush The Eggs 1502
         Story.ChainQuest(1502);
-        
+
         // Heat ‘Em Up! 1503
         Story.MapItemQuest(1503, "lair", 754, 12);
 

--- a/Story/LordsofChaos/MountDoomSkull.cs
+++ b/Story/LordsofChaos/MountDoomSkull.cs
@@ -38,7 +38,7 @@ public class MountDoomSkull
         Core.SendPackets("%xt%zm%tryQuestComplete%937075%3589%-1%false%wvz%");
         Core.SendPackets("%xt%zm%tryQuestComplete%937075%3590%-1%false%wvz%");
         Core.SendPackets("%xt%zm%tryQuestComplete%937075%3591%-1%false%wvz%");
-        
+
         //Drakath Defeated
         Core.Logger("Doing drakath defeated");
         Core.Jump("NPC2", "Left");

--- a/Story/Manor.cs
+++ b/Story/Manor.cs
@@ -35,7 +35,7 @@ public class Manor
         Story.KillQuest(1060, "Manor", "Frigid Frogdrake");
 
         //Inscrutable Motivation 1061
-       Story.MapItemQuest(1061, "Manor", 404, 10);
+        Story.MapItemQuest(1061, "Manor", 404, 10);
 
         //Paradise is Not So Nice 1062
         Story.KillQuest(1062, "Manor", "Bird of Paradise");

--- a/Story/Marsh2[MEM].cs
+++ b/Story/Marsh2[MEM].cs
@@ -22,7 +22,7 @@ public class Marsh2
             Core.Logger("Marsh 2 Storyline Is Member Only. Skipping this Script");
             return;
         }
-            
+
         if (Core.isCompletedBefore(1481))
             return;
 

--- a/Story/Nukemichi[mem].cs
+++ b/Story/Nukemichi[mem].cs
@@ -32,19 +32,19 @@ public class Nukemichi
 
         // Trusted Sources 1587
         Story.MapItemQuest(1587, "akiba", 794, 10);
-        
+
         // Shades Of Gray 1588
         Story.MapItemQuest(1588, "akiba", 795);
-        
+
         // Hiding In Shadows 1589
         Story.KillQuest(1589, "akiba", "Kage Nopperabo");
 
         // Fading Light 1590
         Story.KillQuest(1590, "akiba", "Kage Nopperabo");
-        
+
         // Candles in the Dark 1591
         Story.MapItemQuest(1591, "akiba", 796, 8);
-        
+
         // Shadow Battle! 1592
         Story.KillQuest(1592, "akiba", "Shadow Nukemichi");
     }

--- a/Story/River.cs
+++ b/Story/River.cs
@@ -29,10 +29,10 @@ public class River
 
         // Restocking 64
         Story.KillQuest(64, "river", "Zardman Fisher");
-        
+
         // Spear Sabotage 65
         Story.KillQuest(65, "river", "Zardman Fisher");
-        
+
         // Retaliation 66
         Story.KillQuest(66, "river", "Kuro");
 
@@ -41,7 +41,7 @@ public class River
             Core.Logger("You must be a Member to complete Fishing Bait and Flood of Power quests.");
             return;
         }
-        
+
         // Fishing Bait 72
         Story.KillQuest(72, "river", "Kuro");
 

--- a/Story/SepulchureSaga/CoreSepulchure.cs
+++ b/Story/SepulchureSaga/CoreSepulchure.cs
@@ -40,35 +40,35 @@ public class CoreSepulchure
         // The Taint Spreads 6333
         Story.MapItemQuest(6333, "scarsgarde", 5864, 6);
         Story.KillQuest(6333, "scarsgarde", "VenomWing");
-        
+
         // Beauty Twisted 6334
         Story.KillQuest(6334, "scarsgarde", "Garde Grif");
-        
+
         // Element of Surprise 6335
         Story.MapItemQuest(6335, "scarsgarde", 5865, 5);
         Story.KillQuest(6335, "scarsgarde", "Tree");
-        
+
         // (Take the) Watch Out 6336
         Story.KillQuest(6336, "scarsgarde", new[] { "Garde Watch", "Garde Pikeman" });
-        
+
         // False Hoods 6337
         Story.KillQuest(6337, "scarsgarde", new[] { "Garde Watch", "Garde Watch", "Garde Watch", "Garde Watch", "Garde Watch", "Garde Watch", "Garde Watch" });
-        
+
         // Pass for Real 6338
         Story.MapItemQuest(6338, "scarsgarde", new[] { 5866, 5867 });
         Story.KillQuest(6338, "scarsgarde", new[] { "Garde Knight", "Garde Pikeman", "Garde Knight" });
-        
+
         // Hidden in Plain Sight 6339
         Story.MapItemQuest(6339, "scarsgarde", 5868, 8);
         Story.MapItemQuest(6339, "scarsgarde", 5869);
-        
+
         // Stay Strong Keep Steady 6340
         Story.KillQuest(6340, "scarsgarde", new[] { "Garde Knight", "Garde Pikeman" });
-        
+
         // The Final Fight 6341
         Core.EquipClass(ClassType.Solo);
         Story.KillQuest(6341, "scarsgarde", "Garde Captain");
-        
+
         // Arm the Army 6342
         Story.KillQuest(6342, "scarsgarde", new[] { "Garde Watch", "Garde Pikeman", "Garde Knight" });
     }
@@ -81,43 +81,43 @@ public class CoreSepulchure
             return;
 
         Story.PreLoad(this);
-        
+
         // Who goes there? 6343
         Core.EquipClass(ClassType.Farm);
         Story.MapItemQuest(6343, "scarsgarde", 5861);
-        
+
         // The Taint Spreads 6344
         Story.MapItemQuest(6344, "scarsgarde", 5864, 6);
         Story.KillQuest(6344, "scarsgarde", "VenomWing");
-        
+
         // Beauty Twisted 6345
         Story.KillQuest(6345, "scarsgarde", "Garde Grif");
-        
+
         // Element of Surprise 6346
         Story.MapItemQuest(6346, "scarsgarde", 5865, 5);
         Story.KillQuest(6346, "scarsgarde", "Tree");
-        
+
         // (Take the) Watch Out 6347
         Story.KillQuest(6347, "scarsgarde", new[] { "Garde Watch", "Garde Pikeman" });
-        
+
         // False Hoods 6348
         Story.KillQuest(6348, "scarsgarde", new[] { "Garde Watch", "Garde Watch", "Garde Watch", "Garde Watch", "Garde Watch", "Garde Watch", "Garde Watch" });
-        
+
         // Pass for Real 6349
         Story.MapItemQuest(6349, "scarsgarde", new[] { 5866, 5867 });
         Story.KillQuest(6349, "scarsgarde", new[] { "Garde Knight", "Garde Pikeman", "Garde Knight" });
-        
+
         // Hidden in Plain Sight 6350
         Story.MapItemQuest(6350, "scarsgarde", 5868, 8);
         Story.MapItemQuest(6350, "scarsgarde", 5869);
-        
+
         // Stay Strong Keep Steady 6351
         Story.KillQuest(6351, "scarsgarde", new[] { "Garde Knight", "Garde Pikeman" });
-        
+
         // The Final Fight 6352
         Core.EquipClass(ClassType.Solo);
         Story.KillQuest(6352, "scarsgarde", "Garde Captain");
-        
+
         // Arm the Army 6353
         Story.KillQuest(6353, "scarsgarde", new[] { "Garde Watch", "Garde Pikeman", "Garde Knight" });
     }
@@ -130,29 +130,29 @@ public class CoreSepulchure
             return;
 
         Story.PreLoad(this);
-        
+
         // Come On Get Ready! 6356
         Core.EquipClass(ClassType.Farm);
         Story.BuyQuest(6356, "valleyofdoom", 1599, "Valen Gear", 1);
-        
+
         // Scout the Valley 6357
         Story.KillQuest(6357, "valleyofdoom", "Shadow Imp");
-        
+
         // Gather Energy 6358
         Story.KillQuest(6358, "valleyofdoom", "Shadow Imp");
-        
+
         // Do I Have To Spell It Out? 6359
         Story.MapItemQuest(6359, "valleyofdoom", 5873, 8);
-        
+
         // Get Through the Shadows 6360
         Story.KillQuest(6360, "valleyofdoom", new[] { "Shadow Beast", "Shadow Person" });
-        
+
         // Get the Key 6361
         Story.KillQuest(6361, "valleyofdoom", "Doom Guardian");
-        
+
         // Confront the Champion of Darkness 6362
         Story.MapItemQuest(6362, "valleyofdoom", 5872);
-        
+
         // Destroy the Arsenal 6363
         if (!Story.QuestProgression(6363))
         {
@@ -164,7 +164,7 @@ public class CoreSepulchure
             Core.KillMonster("valleyofdoom", "r8", "Left", "Doom Knight Armor", "Doom Knight Armor Destroyed");
             Core.EnsureComplete(6363);
         }
-        
+
         // Defeat the Armor 6364
         Core.EquipClass(ClassType.Solo);
         if (!Story.QuestProgression(6364))
@@ -173,60 +173,60 @@ public class CoreSepulchure
             Core.KillMonster("valleyofdoom", "r8a", "Left", 3801);
             Core.EnsureComplete(6364);
         }
-        
+
         // Secure the Chest 6365
         Story.MapItemQuest(6365, "guardiantower", 5871);
-        
+
         // Get Some Goo 6366
         Story.KillQuest(6366, "guardiantower", "Slime");
-        
+
         // Retrieve the Wand 6367
         Core.EquipClass(ClassType.Solo);
         Story.KillQuest(6367, "guardiantower", "Yargol Magebane");
-        
+
         // The Wedding 6368
         Core.Logger("Autocompleted");
-        
+
         // Gather the Shadows 6369
         Core.EquipClass(ClassType.Farm);
         Story.KillQuest(6369, "valleyofdoom", "Shadow Imp");
-        
+
         // Choose Your Path 6370
         Story.MapItemQuest(6370, "ebonslate", 5895);
-        
+
         // Mind Control 6371
         Story.KillQuest(6371, "ebonslate", "Mind Con-Troll");
-        
+
         // Sp-Eye on You 6372
         Story.KillQuest(6372, "ebonslate", "Sp-Eye");
-        
+
         // Lower the Drawbridge 6373
         Story.MapItemQuest(6373, "ebonslate", 5896);
         Story.KillQuest(6373, "ebonslate", "Ebonslate Guard");
-        
+
         // Get the Key 6374
         Story.MapItemQuest(6374, "ebonslate", 5897);
         Story.KillQuest(6374, "ebonslate", new[] { "Lycan Brute", "Lycan Brute" });
-        
+
         // Break Down the Door 6375
         Story.MapItemQuest(6375, "ebonslate", 5898);
-        
+
         // Question the Knights 6376
         Story.KillQuest(6376, "ebonslate", "Ebonslate Knight");
-        
+
         // Troll the Trolls 6377
         Story.KillQuest(6377, "ebonslate", "Mind Con-Troll");
-        
+
         // Get Through the Barrier 6378
         Story.MapItemQuest(6378, "ebonslate", 5899);
-        
+
         // Disarm the Knights 6379
         Story.KillQuest(6379, "ebonslate", "Ebonslate Knight");
-        
+
         // Bruise the Bruiser 6380
         Core.EquipClass(ClassType.Solo);
         Story.KillQuest(6380, "ebonslate", "Ebonslate Bruiser");
-        
+
         // Take Down Dethrix 6381
         if (Story.QuestProgression(6381))
         {
@@ -235,82 +235,82 @@ public class CoreSepulchure
             Bot.Combat.Attack("Dethrix");
             Bot.Sleep(10000);
         }
-        
+
         // Please Fix Me 6382
         Story.KillQuest(6382, "guardiantowerb", "Slime");
-        
+
         // Get the Slime 6383
         Story.KillQuest(6383, "guardiantowerb", "Slime");
-        
+
         // Reach for the Heart 6384
         Core.EquipClass(ClassType.Solo);
         Story.KillQuest(6384, "guardiantowerb", "Yargol Magebane");
-        
+
         // Get More Shadows 6385
         Core.EquipClass(ClassType.Farm);
         Story.KillQuest(6385, "guardiantowerb", "Slime");
-        
+
         // Garen's Key 6386
         Story.KillQuest(6386, "guardiantowerb", new[] { "Guardian Selby", "Guardian Garen" });
-        
+
         // Selby's Key 6387
         Story.KillQuest(6387, "guardiantowerb", new[] { "Guardian Garen", "Guardian Selby" });
-        
+
         // Get Rid of Bolton 6388
         Story.MapItemQuest(6388, "guardiantowerb", 5901);
         Story.KillQuest(6388, "guardiantowerb", "Guardian Bolton");
-        
+
         // Get Rid of the Imps 6389
         Story.KillQuest(6389, "ebondungeon", "Ebonslate Imp");
-        
+
         // Get Into the Dungeon 6390
         Story.MapItemQuest(6390, "ebondungeon", 5902);
-        
+
         // Destroy the Guards 6391
         Story.KillQuest(6391, "ebondungeon", "Ebon Dungeon Guard");
-        
+
         // Get the Key 6392
         Story.KillQuest(6392, "ebondungeon", "Elite Dungeon Guard");
-        
+
         // Find Lynaria 6393
         Story.MapItemQuest(6393, "ebondungeon", new[] { 5903, 5904 });
-        
+
         // Destroy Dethrix 6394
         Core.EquipClass(ClassType.Solo);
         Story.KillQuest(6394, "ebondungeon", "Dethrix");
-        
+
         // Siphon the Power (Farming) 6395
         Story.KillQuest(6395, "ebondungeon", "Ebon Dungeon Guard");
-        
+
         // He's Not Your Friend 6399
         Story.KillQuest(6399, "alteonfight", "King Alteon");
-        
+
         // Defeat the Dragon 6400
         Story.MapItemQuest(6400, "alteonfight", 5910);
-        
+
         // Power Boost 6401
         Core.EquipClass(ClassType.Farm);
         Story.KillQuest(6401, "darkplane", "Shadow Beast");
-        
+
         // Take His Knights 6402
         Story.KillQuest(6402, "darkplane", "Guardian Knight");
-        
+
         // Destroy the Light 6403
         Story.KillQuest(6403, "darkplane", "Light Spirit");
-        
+
         // More Power! 6404
         Story.KillQuest(6404, "darkplane", "Shadow Beast");
-        
+
         // Destroy the Force Field 6405
         Story.MapItemQuest(6405, "darkplane", 5911);
-        
+
         // Defeat the Battalion 6406
         Story.KillQuest(6406, "darkplane", "Guardian Knight");
-        
+
         // Destroy the Beast 6407
         Core.EquipClass(ClassType.Solo);
         Story.KillQuest(6407, "darkplane", "Victorious");
-        
+
         // Learn from the Past 6408
         Story.KillQuest(6408, "darkplane", "Shadow Beast");
     }
@@ -323,106 +323,106 @@ public class CoreSepulchure
             return;
 
         Story.PreLoad(this);
-        
+
         // Fluid Dynamics 6539
         Core.EquipClass(ClassType.Farm);
         Story.KillQuest(6539, "noxustower", "Slimeskull");
-        
+
         // M-ossification 6540
         Story.KillQuest(6540, "noxustower", "Doomwood Treeant");
-        
+
         // A-gore-able 6541
         Story.KillQuest(6541, "noxustower", "Sanguine Souleater");
-        
+
         // Raw-r 6542
         Story.KillQuest(6542, "noxustower", "Lightguard Caster");
-        
+
         // Light 'em Up 6543
         Story.KillQuest(6543, "noxustower", "Lightguard Caster");
-        
+
         // Spellbound 6544
         Story.MapItemQuest(6544, "noxustower", 6018, 4);
         Story.KillQuest(6544, "noxustower", "Lightguard Caster");
-        
+
         // Lupine Resurrection 6545
         Story.KillQuest(6545, "noxustower", "Lightguard Wolf");
-        
+
         // Spying on the Light 6546
         Story.KillQuest(6546, "noxustower", "Lightguard Paladin");
-        
+
         // Illusory Disguise 6547
         Story.KillQuest(6547, "noxustower", new[] { "Lightguard Caster", "Doomwood Treeant", "Slimeskull" });
-        
+
         // Test the Disguise 6548
         Story.MapItemQuest(6548, "noxustower", 6019);
-        
+
         // Get Alteon 6549
         Story.MapItemQuest(6549, "noxustower", 6020);
-        
+
         // Hammer Time 6550
         Story.KillQuest(6550, "noxustower", "General Goldhammer");
-        
+
         // Lightguard Medals 6560
         Story.KillQuest(6560, "lightguardwar", "Citadel Crusader");
-        
+
         // Mega Lightguard Medals 6561
         Story.KillQuest(6561, "lightguardwar", "Citadel Crusader");
-        
+
         // Bone Marrow 6562
         Story.KillQuest(6562, "lightguardwar", "Citadel Crusader");
-        
+
         // Ooze it up 6563
         Story.KillQuest(6563, "lightguardwar", "Slimeskull");
-        
+
         // Seize the Seige (Engine) 6564
         Story.KillQuest(6564, "lightguardwar", "Lightguard Engine");
-        
+
         // Darken the Light 6565
         Story.KillQuest(6565, "lightguardwar", "Scorching Flame");
-        
+
         // Get the Powder 6566
         Story.KillQuest(6566, "lightguardwar", "Citadel Crusader");
-        
+
         // Destroy the Shield 6567
         Story.KillQuest(6567, "lightguardwar", "Sigrid Sunshield");
-        
+
         // Such a Mess 6581
         Story.MapItemQuest(6581, "lumafortress", 6098, 8);
         Story.KillQuest(6581, "lumafortress", "Invasive Shadow");
-        
+
         // Herbs Needed 6582
         Story.MapItemQuest(6582, "lumafortress", 6099, 7);
         Story.KillQuest(6582, "lumafortress", "Light Treeant");
-        
+
         // Shine a Light 6583
         Story.KillQuest(6583, "lumafortress", "Light Elemental");
-        
+
         // Hapless? 6584
         Story.KillQuest(6584, "lumafortress", "Hapless Skeleton");
-        
+
         // How 'bout them Apples 6585
         Story.KillQuest(6585, "lumafortress", "Light Treeant");
-        
+
         // Make an Offering 6586
         Story.MapItemQuest(6586, "lumafortress", 6100);
         Story.KillQuest(6586, "lumafortress", "Lightwing");
-        
+
         // Test the Spell Again! 6587
         Story.MapItemQuest(6587, "lumafortress", 6101);
-        
+
         // Gather the Light 6588
         Story.KillQuest(6588, "lumafortress", "Light Elemental");
-        
+
         // Banish the Shadows 6589
         Story.KillQuest(6589, "lumafortress", "Living Shadow");
-        
+
         // So Many Minions 6590
         Story.KillQuest(6590, "lumafortress", "Skeleton Minion");
-        
+
         // Corrupted Light 6591
         Core.EquipClass(ClassType.Solo);
         Story.KillQuest(6591, "lumafortress", "Corrupted Luma");
-        
+
         // Star Light Star Bright 6592
         Story.KillQuest(6592, "lumafortress", "Light Elemental");
     }

--- a/Story/ShadowsOfWar/CoreSoW.cs
+++ b/Story/ShadowsOfWar/CoreSoW.cs
@@ -86,7 +86,7 @@ public class CoreSoW
             Bot.Options.AttackWithoutTarget = false;
             Core.EnsureComplete(6852);
             Bot.Wait.ForMapLoad("shadowwar"); //game will force you bac to shadowar-1 ._. so you're welcome.
-            Core.Join("whitemap-100000"); 
+            Core.Join("whitemap-100000");
         }
     }
 

--- a/Story/Shattersword.cs
+++ b/Story/Shattersword.cs
@@ -21,7 +21,7 @@ public class Shattersword
     {
         if (Core.isCompletedBefore(2690))
             return;
-        
+
         if (!Core.IsMember)
         {
             Core.Logger("Shattersword is a member-only storyline.");

--- a/Story/XansLair.cs
+++ b/Story/XansLair.cs
@@ -34,66 +34,66 @@ public class XansLair
 
         // Level 1 1242
         Story.KillQuest(1242, "volcano", "Lava Golem");
-      
+
         // Level 2 1243
         Story.MapItemQuest(1243, "volcano", 526, 3);
         Story.KillQuest(1243, "volcano", "Fire Imp");
-       
+
         // Level 3 1244
         Story.KillQuest(1244, "volcano", "Fire Imp");
-      
+
         // Level 4 1245
         Story.MapItemQuest(1245, "volcano", 527, 8);
         Story.KillQuest(1245, "volcano", "Lava Golem");
-      
+
         // Level 5 1246
         Story.KillQuest(1246, "volcano", "Fire Imp");
-      
+
         // Level 6 1247
         Story.KillQuest(1247, "volcano", "Fire Imp");
-      
+
         // Level 7 1248
         Story.MapItemQuest(1248, "volcano", 528, 12);
-       
+
         // Level 8 1249
         Story.KillQuest(1249, "volcano", "Flamethrower Dwakel");
-       
+
         // Level 9 1250
         Story.KillQuest(1250, "volcano", "Fire Imp");
         Story.MapItemQuest(1250, "volcano", 529, 8);
-      
+
         // Level 10 1251
         Story.KillQuest(1251, "volcano", "Flamethrower Dwakel");
-       
+
         // Level 11 1252
         Story.MapItemQuest(1252, "volcano", 530, 10);
         Story.KillQuest(1252, "volcano", "Fire Imp");
-       
+
         // Level 12 1253
         Story.KillQuest(1253, "volcano", "Flame Elemental");
-        
+
         // Level 13 1254
         Story.MapItemQuest(1254, "volcano", 531, 12);
-        
+
         // Level 14 1255
         Story.KillQuest(1255, "volcano", "Fire Imp");
-     
+
         // Level 15 1256
         Story.KillQuest(1256, "volcano", "Fire Imp");
-       
+
         // Level 16 1257
         Story.MapItemQuest(1257, "volcano", 532, 10);
-        
+
         // Level 17 1258
         Story.KillQuest(1258, "volcano", "Flamethrower Dwakel");
-        
+
         // Level 18 1259
         Story.KillQuest(1259, "volcano", new[] { "Fire Imp", "Flame Elemental" });
-        
+
         // Level 19 1260
         Story.MapItemQuest(1260, "volcano", 533, 6);
         Story.KillQuest(1260, "volcano", "Fire Imp");
-        
+
         // Level 20 1261
         Story.KillQuest(1261, "volcano", "Magman");
     }
@@ -107,22 +107,22 @@ public class XansLair
 
         // A Town Divided 1733
         Story.MapItemQuest(1733, "xantown", 922);
-        
+
         // The Miller's Key 1734
         Story.KillQuest(1734, "xantown", "Fire Imp");
-        
+
         // Trailblazer 1735
         Story.KillQuest(1735, "xantown", "Fire Imp");
-        
+
         // Fire Brigade Of One 1736
         Story.KillQuest(1736, "xantown", "Fire Imp");
-        
+
         // Fire Control 1737
         Story.MapItemQuest(1737, "xantown", 923, 4);
-        
+
         // Andesi's Family Pendant 1738
         Story.MapItemQuest(1738, "xantown", 924);
-        
+
         // Signed, Seared, Delivered 1739
         Story.MapItemQuest(1739, "xantown", 925);
     }
@@ -147,23 +147,23 @@ public class XansLair
 
         // Locate The Sealed Library 2151
         Story.MapItemQuest(2151, "xancave", 1220);
-        
+
         // A Powered Library Lock 2152
         Story.KillQuest(2152, "xancave", "Lava Goblin");
-        
+
         // Luminate the Library Lock 2153
         Story.MapItemQuest(2153, "xancave", 1221);
-        
+
         // Defend the Library! 2154
         Story.KillQuest(2154, "xancave", "Lava Goblin");
-        
+
         // Crossing Over 2155
         Story.MapItemQuest(2155, "xancave", 1223, 8);
         Story.KillQuest(2155, "xancave", new[] { "Lava Goblin", "Lava Goblin" });
-        
+
         // Guardian Of Shurpu 2156
         Story.KillQuest(2156, "xancave", "Shurpu Ring Guardian");
-        
+
         // Face Xan 2157
         Story.MapItemQuest(2157, "xancave", 1222);
     }

--- a/Templates/MergeTemplate.cs
+++ b/Templates/MergeTemplate.cs
@@ -30,10 +30,10 @@ public class MergeTemplate
         Core.SetOptions(false);
     }
 
-    public void BuyAllMerge()
+    public void BuyAllMerge(string buyOnlyThis = null, mergeOptionsEnum? buyMode = null)
     {
         //Only edit the map and shopID here
-        Adv.StartBuyAllMerge("map", 1234, findIngredients);
+        Adv.StartBuyAllMerge("map", 1234, findIngredients, buyOnlyThis, buyMode: buyMode);
 
         #region Dont edit this part
         void findIngredients()

--- a/Tools/ChooseBestGear.cs
+++ b/Tools/ChooseBestGear.cs
@@ -48,5 +48,5 @@ public class ChooseBestGear
         if (EnhanceEquipment)
             Adv.SmartEnhance(Bot.Player.CurrentClass.Name);
     }
-    
+
 }

--- a/Tools/ForDevelopers/MergeTemplateHelper.cs
+++ b/Tools/ForDevelopers/MergeTemplateHelper.cs
@@ -127,13 +127,13 @@ public class MergeTemplateHelper
         }
         MergeTemplate[blackListIndex] = "        Core.BankingBlackList.AddRange(new[] { \"" + String.Join("\", \"", itemsToLearn) + " \"});";
 
-        int startIndex = Array.IndexOf(MergeTemplate, "        Adv.StartBuyAllMerge(\"map\", 1234, findIngredients);");
+        int startIndex = Array.IndexOf(MergeTemplate, "        Adv.StartBuyAllMerge(\"map\", 1234, findIngredients, buyOnlyThis, buyMode: buyMode);");
         if (startIndex < 0)
         {
             Core.Logger("Failed to find startIndex");
             return;
         }
-        MergeTemplate[startIndex] = $"        Adv.StartBuyAllMerge(\"{map.ToLower()}\", {shopID}, findIngredients);";
+        MergeTemplate[startIndex] = $"        Adv.StartBuyAllMerge(\"{map.ToLower()}\", {shopID}, findIngredients, buyOnlyThis, buyMode: buyMode);";
 
         shopItemNames.Add("    };");
 


### PR DESCRIPTION
Mergeshops now can be called with 1 item param, for example AClass.BuyAllMerge(“Item”);

Formatted the whole code with dotnet
https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-format

Enhancement based on https://docs.google.com/spreadsheets/d/1RoPfjKD4Hy-gP_rETUISMllKoi8VpRkMApZdTPP5fe8/edit?usp=sharing
