### PR TITLE
Fix The Power of Flowers quest

### DIFF
--- a/Story/IsleOfFotia/CoreIsleOfFotia.cs
+++ b/Story/IsleOfFotia/CoreIsleOfFotia.cs
@@ -150,7 +150,7 @@ public class CoreIsleOfFotia
         if (!Story.QuestProgression(3036))
         {
             Core.EnsureAccept(3036);
-            Core.HuntMonster("judgement", Bot.Flash.GetGameObject<string>("world.myAvatar.objData.strGender") == "M" ? "Male Mourner" : "Female Mourner", "Delivered Asphodel Flower", 8);
+            Core.HuntMonster("judgement", Bot.Flash.GetGameObject<string>("world.myAvatar.objData.strGender") == "F" ? "Male Mourner" : "Female Mourner", "Delivered Asphodel Flower", 8);
             Core.EnsureComplete(3036);
         }
 


### PR DESCRIPTION
Fixes "The Power of Flowers" quest as the ternary operator was wrong, you need to hunt Male Mourners as a female, not as a male