### PR TITLE
Fix 0TheBlindingLightofDestiny.cs

### DIFF
--- a/Good/BLoD/0TheBlindingLightofDestiny.cs
+++ b/Good/BLoD/0TheBlindingLightofDestiny.cs
@@ -33,7 +33,7 @@ public class TheBlindingLightofDestiny
     {
         Core.SetOptions();
 
-        BLOD.BlindingLightOfDestiny();
+        BLOD.BlindingLightOfDestiny(Bot.Config!.Get<BLODMethod>("BLODMethod"));
 
         Core.SetOptions(false);
     }


### PR DESCRIPTION
Previously, BlindingLightOfDestiny was called with no arguments. Now, the user's "BLODMethod" selection is passed to it.