### PR TITLE
Fix CursedWazikashi.cs

### DIFF
--- a/CoreBots.cs
+++ b/CoreBots.cs
@@ -3253,7 +3253,7 @@ public class CoreBots
                 Jump("R10");
                 Bot.Map.Join(PrivateRooms ? "moonyard-" + PrivateRoomNumber : "moonyard");
                 Bot.Wait.ForMapLoad("moonyard");
-                Bot.Wait.ForItemEquip("j6");
+                Bot.Wait.ForItemEquip("j5");
                 SimpleQuestBypass((28, 35));
                 Bot.Map.Join(PrivateRooms ? $"{map}-" + PrivateRoomNumber : map);
                 Bot.Wait.ForMapLoad(strippedMap);

--- a/Other/Pets/CursedWazikashi.cs
+++ b/Other/Pets/CursedWazikashi.cs
@@ -23,6 +23,9 @@ public class CursedWazikashi
 
     public void CursedWakizashiPet()
     {
+        if (Core.CheckInventory("Cursed Wakizashi Pet", toInv: false))
+            return;
+
         Core.AddDrop(79316, 79317, 79318, 79319, 79320);
 
         // Get item to  start quest [required]
@@ -38,7 +41,7 @@ public class CursedWazikashi
 
         // Master Pockey Ball
         if (!Core.CheckInventory(79320))
-            Core.GetMapItem(12046, 1, "superslayin");
+            Core.GetMapItem(12047, 1, "superslayin");
 
         // Broken Bamboo Chunk
         Core.HuntMonster("shogunwar", "Bamboo Treeant", "Broken Bamboo Chunk", isTemp: false);


### PR DESCRIPTION
Fix item ID and improve item check and equip logic

- Corrected the item ID for "Master Pockey Ball" map item.
- Updated the bot to wait for the "j5" armor instead of "j6" when joining the "moonyard" map.
- Added an inventory check to prevent duplicate farming of "Cursed Wakizashi Pet".