### PR TITLE
Fixes Issue related with IODA LR stopping the script

### DIFF
--- a/Legion/Revenant/CoreLR.cs
+++ b/Legion/Revenant/CoreLR.cs
@@ -69,7 +69,7 @@ public class CoreLR
     public void GetLR(bool rankUpClass)
     {
         // Tests for IODA LR since it does not provide the badge and currently has the same ID as normal LR
-        if (Core.CheckInventory("Legion Revenant") && Core.Badges.Contains(badge => badge.Name == "Legion Revenant"))
+        if (Core.CheckInventory("Legion Revenant") && Core.Badges.Contains("Legion Revenant"))
             return;
 
         Legion.JoinLegion();

--- a/Legion/Revenant/CoreLR.cs
+++ b/Legion/Revenant/CoreLR.cs
@@ -69,7 +69,7 @@ public class CoreLR
     public void GetLR(bool rankUpClass)
     {
         // Tests for IODA LR since it does not provide the badge and currently has the same ID as normal LR
-        if (Core.CheckInventory("Legion Revenant") && Core.Badges.Contains(badge => badge.Name == "Legion Revenant");)
+        if (Core.CheckInventory("Legion Revenant") && Core.Badges.Contains(badge => badge.Name == "Legion Revenant"))
             return;
 
         Legion.JoinLegion();

--- a/Legion/Revenant/CoreLR.cs
+++ b/Legion/Revenant/CoreLR.cs
@@ -68,7 +68,8 @@ public class CoreLR
 
     public void GetLR(bool rankUpClass)
     {
-        if (Core.CheckInventory("Legion Revenant"))
+        // Tests for IODA LR since it does not provide the badge and currently has the same ID as normal LR
+        if (Core.CheckInventory("Legion Revenant") && Core.Badges.Contains(badge => badge.Name == "Legion Revenant");)
             return;
 
         Legion.JoinLegion();


### PR DESCRIPTION
The current implementation of the LR class has the same ID/Name has the IODA version, so when the script starts to search for the LR in inventory it will find one and think that is enought and that the script is done, but it should really check for the badge and for the class in inventory in the user since that is the real proof that the user already has the farm and an existing LR class in inventory/bank.