### PR TITLE
waitForParty synchronization with pipes

### DIFF
--- a/Army/ArmyFarm/ArmyIceWing.cs
+++ b/Army/ArmyFarm/ArmyIceWing.cs
@@ -68,7 +68,7 @@ public class IceWingLevelingArmy
             Core.AddDrop(item);
 
         Core.EquipClass(classType);
-        //Army.waitForParty(map, item);
+        Army.waitForParty(map, item);
         Core.FarmingLogger(item, quant);
         
         Core.Join(map);

--- a/Army/ArmyFarm/ArmyLeveling.cs
+++ b/Army/ArmyFarm/ArmyLeveling.cs
@@ -75,7 +75,7 @@ public class ArmyLeveling
         {
             case MethodV2.IceStormArena:
                 Core.EquipClass(ClassType.Farm);
-                //Army.waitForParty("whitemap");
+                Army.waitForParty("whitemap");
                 Army.AggroMonCells("r22");
                 Army.AggroMonStart("icestormarena");
                 Army.DivideOnCells("r22");
@@ -87,7 +87,7 @@ public class ArmyLeveling
                 Core.JumpWait();
                 Farm.ToggleBoost(BoostType.Experience, false);
                 Farm.ToggleBoost(BoostType.Gold, false);
-                //Army.waitForParty("whitemap");
+                Army.waitForParty("whitemap");
                 break;
 
             case MethodV2.IceStormUnder:
@@ -95,7 +95,7 @@ public class ArmyLeveling
                     Core.Logger("Player is below lvl 75, which is\n" +
                     "required for the map. --stopping", stopBot: true);
                 Core.EquipClass(ClassType.Farm);
-                //Army.waitForParty("whitemap");
+                Army.waitForParty("whitemap");
                 Army.AggroMonCells("r2");
                 Army.AggroMonStart("icestormunder");
                 Army.DivideOnCells("r2");
@@ -106,7 +106,7 @@ public class ArmyLeveling
                 Core.JumpWait();
                 Farm.ToggleBoost(BoostType.Experience, false);
                 Farm.ToggleBoost(BoostType.Gold, false);
-                //Army.waitForParty("whitemap");
+                Army.waitForParty("whitemap");
                 break;
 
             case MethodV2.IceWing:
@@ -114,7 +114,7 @@ public class ArmyLeveling
                     Core.Logger("Player is below lvl 75, required for\n" +
                     "the map --stopping", stopBot: true);
                 Core.EquipClass(ClassType.Solo);
-                //Army.waitForParty("whitemap");
+                Army.waitForParty("whitemap");
                 Army.AggroMonCells("Enter");
                 Army.AggroMonStart("icewing");
                 Army.DivideOnCells("Enter");
@@ -126,14 +126,14 @@ public class ArmyLeveling
                 Core.JumpWait();
                 Farm.ToggleBoost(BoostType.Experience, false);
                 Farm.ToggleBoost(BoostType.Gold, false);
-                //Army.waitForParty("whitemap");
+                Army.waitForParty("whitemap");
                 break;
 
             case MethodV2.SevenCirclesWar:
             HakuNerfed:
                 SC.CirclesWar(true);
                 Core.EquipClass(ClassType.Farm);
-                //Army.waitForParty("whitemap");
+                Army.waitForParty("whitemap");
                 Army.AggroMonCells("Enter", "r2", "r3");
                 Army.AggroMonStart("sevencircleswar");
                 Army.DivideOnCells("Enter", "r2", "r3");
@@ -145,14 +145,14 @@ public class ArmyLeveling
                 Core.JumpWait();
                 Farm.ToggleBoost(BoostType.Experience, false);
                 Farm.ToggleBoost(BoostType.Gold, false);
-                //Army.waitForParty("whitemap");
+                Army.waitForParty("whitemap");
                 break;
 
             case MethodV2.Streamwar:
                 SoW.TimestreamWar();
                 Core.EquipClass(ClassType.Farm);
                 Core.AddDrop("Prismatic Seams");
-                //Army.waitForParty("whitemap");
+                Army.waitForParty("whitemap");
                 Army.AggroMonCells("r3a");
                 Army.AggroMonStart("streamwar");
                 Army.DivideOnCells("r3a");
@@ -164,7 +164,7 @@ public class ArmyLeveling
                 Core.JumpWait();
                 Farm.ToggleBoost(BoostType.Experience, false);
                 Farm.ToggleBoost(BoostType.Gold, false);
-                //Army.waitForParty("whitemap");
+                Army.waitForParty("whitemap");
                 break;
 
 
@@ -212,7 +212,7 @@ public class ArmyLeveling
                 Core.JumpWait();
                 Farm.ToggleBoost(BoostType.Experience, false);
                 Farm.ToggleBoost(BoostType.Gold, false);
-                //Army.waitForParty("whitemap");
+                Army.waitForParty("whitemap");
                 break;
 
             case MethodV2.HakuWar:
@@ -243,7 +243,7 @@ public class ArmyLeveling
                 /*
                 case Method.Method:
                 Core.EquipClass(ClassType.ClassType);
-                //Army.waitForParty("map");
+                Army.waitForParty("map");
                 Army.AggroMonCells(cells);
                 Army.AggroMonStart("map");
                 Army.DivideOnCells("cell");
@@ -252,7 +252,7 @@ public class ArmyLeveling
                     Bot.Combat.Attack("*");
                 Army.AggroMonStop(true);
                 Core.JumpWait();
-                //Army.waitForParty("whitemap");
+                Army.waitForParty("whitemap");
                 break;
 
                 */
@@ -310,7 +310,7 @@ public class ArmyLeveling
                 break;
         }
         Core.JumpWait();
-        //Army.waitForParty("Whitemap");
+        Army.waitForParty("Whitemap");
     }
 
 }

--- a/Army/ArmyFarm/Rep/ArmyBlackSmithRep.cs
+++ b/Army/ArmyFarm/Rep/ArmyBlackSmithRep.cs
@@ -74,14 +74,14 @@ public class ArmyBlackSmithRep
             Core.EquipClass(ClassType.Farm);
 
             Armykill("hydrachallenge", "Hydra Scale Piece", 75);
-            //Army.waitForParty("maul");
+            Army.waitForParty("maul");
 
             Core.EquipClass(ClassType.Solo);
             Armykill("maul", "Creature Shard");
-            //Army.waitForParty("towerofdoom");
+            Army.waitForParty("towerofdoom");
 
             Armykill("towerofdoom", "Monster Trophy", 15);
-            //Army.waitForParty("hydrachallenge");
+            Army.waitForParty("hydrachallenge");
 
             Core.EnsureComplete(8736);
         }

--- a/Army/ArmyFarm/Rep/CoreArmyRep.cs
+++ b/Army/ArmyFarm/Rep/CoreArmyRep.cs
@@ -206,7 +206,7 @@ public class CoreArmyRep
         Farm.ToggleBoost(BoostType.Reputation, false);
 
         // Wait for the party
-        //Army.waitForParty("whitemap");
+        Army.waitForParty("whitemap");
     }
     public int FactionRank(string faction) => Bot.Reputation.GetRank(faction);
 }

--- a/Army/ArmyFarm/Rep/RepTemplate.cs
+++ b/Army/ArmyFarm/Rep/RepTemplate.cs
@@ -74,7 +74,7 @@ public class ArmyRepTemplate
         Army.AggroMonStop(true);
         Farm.ToggleBoost(BoostType.Reputation, false);
         Core.CancelRegisteredQuests();
-        //Army.waitForParty("whitemap");
+        Army.waitForParty("whitemap");
     }
 }
 

--- a/Army/ArmyHollowBorn/ArmyHollowSoul.cs
+++ b/Army/ArmyHollowBorn/ArmyHollowSoul.cs
@@ -74,7 +74,7 @@ public class ArmyHollowSoul
 
         Core.CancelRegisteredQuests();
         Army.AggroMonStop(true);
-        //Army.waitForParty("whitemap", "Hollow Soul");
+        Army.waitForParty("whitemap", "Hollow Soul");
     }
 
     void ArmyHunt(int[] MonsterMapIDs, string[] cells, string aggroMonStart, string itemName, int quant = 1)

--- a/Army/ArmyLegion/ArmyLRFull.cs
+++ b/Army/ArmyLegion/ArmyLRFull.cs
@@ -192,13 +192,13 @@ public class ArmyLR
         while (!Bot.ShouldExit && !Core.CheckInventory("Revenant's Spellscroll", quant))
         {
             ArmyHunt("judgement", "Aeacus Empowered", ClassType.Solo, 50, false);
-            // //Army.waitForParty("revenant");
+            // Army.waitForParty("revenant");
             ArmyHunt("revenant", "Tethered Soul", ClassType.Farm, 300);
-            // //Army.waitForParty("shadowrealmpast");
+            // Army.waitForParty("shadowrealmpast");
             ArmyHunt("shadowrealmpast", "Darkened Essence", ClassType.Farm, 500);
-            // //Army.waitForParty("necrodungeon");
+            // Army.waitForParty("necrodungeon");
             ArmyHunt("necrodungeon", "Dracolich Contract", ClassType.Farm, 1000);
-            // //Army.waitForParty("judgement");
+            // Army.waitForParty("judgement");
 
             Bot.Wait.ForPickup("Revenant's Spellscroll");
         }
@@ -218,25 +218,25 @@ public class ArmyLR
         while (!Bot.ShouldExit && !Core.CheckInventory("Conquest Wreath", quant))
         {
             ArmyHunt("doomvault", "Grim Cohort Conquered", ClassType.Farm, 500);
-            // //Army.waitForParty("mummies");
+            // Army.waitForParty("mummies");
             ArmyHunt("mummies", "Ancient Cohort Conquered", ClassType.Farm, 500);
-            // //Army.waitForParty("wrath");
+            // Army.waitForParty("wrath");
             ArmyHunt("wrath", "Pirate Cohort Conquered", ClassType.Farm, 500);
-            // //Army.waitForParty("doomwar");
+            // Army.waitForParty("doomwar");
             ArmyHunt("doomwar", "Battleon Cohort Conquered", ClassType.Farm, 500);
-            // //Army.waitForParty("overworld");
+            // Army.waitForParty("overworld");
             ArmyHunt("overworld", "Mirror Cohort Conquered", ClassType.Farm, 500);
-            // //Army.waitForParty("deathpits");
+            // Army.waitForParty("deathpits");
             ArmyHunt("deathpits", "Darkblood Cohort Conquered", ClassType.Farm, 500);
-            // //Army.waitForParty("maxius");
+            // Army.waitForParty("maxius");
             ArmyHunt("maxius", "Vampire Cohort Conquered", ClassType.Farm, 500);
-            // //Army.waitForParty("curseshore");
+            // Army.waitForParty("curseshore");
             ArmyHunt("curseshore", "Spirit Cohort Conquered", ClassType.Farm, 500);
-            // //Army.waitForParty("dragonbone");
+            // Army.waitForParty("dragonbone");
             ArmyHunt("dragonbone", "Dragon Cohort Conquered", ClassType.Farm, 500);
-            // //Army.waitForParty("doomwood");
+            // Army.waitForParty("doomwood");
             ArmyHunt("doomwood", "Doomwood Cohort Conquered", ClassType.Farm, 500);
-            // //Army.waitForParty("doomvault");
+            // Army.waitForParty("doomvault");
 
             Bot.Wait.ForPickup("Conquest Wreath");
         }
@@ -273,7 +273,7 @@ public class ArmyLR
             return;
 
         Farm.ToggleBoost(BoostType.Reputation);
-        // //Army.waitForParty("swordhavenbridge");
+        // Army.waitForParty("swordhavenbridge");
         while (!Bot.ShouldExit && (Farm.FactionRank("Good") < 4 && Farm.FactionRank("Evil") < 4))
             ArmyHunt("swordhavenbridge", "Slime in a Jar", ClassType.Farm, 6, true);
         Core.CancelRegisteredQuests();
@@ -286,7 +286,7 @@ public class ArmyLR
             return;
 
         Farm.ToggleBoost(BoostType.Reputation);
-        // //Army.waitForParty("castleundead");
+        // Army.waitForParty("castleundead");
         while (!Bot.ShouldExit && (Farm.FactionRank("Good") < 10 && Farm.FactionRank("Evil") < 10))
             ArmyHunt("castleundead", "Replacement Tibia", ClassType.Farm, 6, true);
         Core.CancelRegisteredQuests();
@@ -320,7 +320,7 @@ public class ArmyLR
     {
         if (Core.CheckInventory("Dage's Favor", quant))
             return;
-        // //Army.waitForParty("evilwarnul");
+        // Army.waitForParty("evilwarnul");
         while (!Bot.ShouldExit && !Core.CheckInventory("Dage's Favor", quant))
             ArmyHunt("evilwarnul", "Dage's Favor", ClassType.Farm, quant);
     }
@@ -334,7 +334,7 @@ public class ArmyLR
         Core.FarmingLogger("Emblem of Dage", quant);
         Core.EquipClass(ClassType.Farm);
 
-        // //Army.waitForParty("shadowblast");
+        // Army.waitForParty("shadowblast");
         while (!Bot.ShouldExit && !Core.CheckInventory("Emblem of Dage", quant))
         {
             ArmyHunt("shadowblast", "Legion Seal", ClassType.Farm, 25);
@@ -373,7 +373,7 @@ public class ArmyLR
 
         Core.FarmingLogger("Dark Token", quant);
         Core.AddDrop("Dark Token");
-        // //Army.waitForParty("seraphicwardage");
+        // Army.waitForParty("seraphicwardage");
         while (!Bot.ShouldExit && !Core.CheckInventory("Dark Token", quant))
             ArmyHunt("seraphicwardage", "Seraphic Commanders Slain", ClassType.Farm, 6);
         Core.CancelRegisteredQuests();
@@ -385,7 +385,7 @@ public class ArmyLR
             return;
 
         Core.FarmingLogger("Legion Token", quant);
-        // //Army.waitForParty("dreadrock");
+        // Army.waitForParty("dreadrock");
         while (!Bot.ShouldExit && !Core.CheckInventory("Legion Token", quant))
             ArmyHunt("dreadrock", "Legion Token", ClassType.Farm, quant);
         Core.CancelRegisteredQuests();
@@ -408,7 +408,7 @@ public class ArmyLR
 
         Core.EquipClass(classType);
         if (Core.CheckInventory(item))
-            //Army.waitForParty("whitemap", item);
+            Army.waitForParty("whitemap", item);
         HandleMap(map, item, quant);
 
         

--- a/Army/ArmyNulgath/ArmyBloodyChaos.cs
+++ b/Army/ArmyNulgath/ArmyBloodyChaos.cs
@@ -72,7 +72,8 @@ public class ArmyBloodyChaos
 
         Core.AddDrop(item);
 
-        //Army.waitForParty(map, item);
+        Core.EquipClass(ClassType.Solo);
+        Army.waitForParty(map, item);
         Core.FarmingLogger(item, quant);
 
         switch (map)

--- a/Army/ArmyNulgath/ArmySupplies.cs
+++ b/Army/ArmyNulgath/ArmySupplies.cs
@@ -121,7 +121,7 @@ public class SuppliesWheelArmy
                 while (!Bot.ShouldExit && !Core.CheckInventory(item.ID, item.MaxStack))
                     ArmyHydra(item.Name, item.MaxStack);
             }
-            //Army.waitForParty("whitemap");
+            Army.waitForParty("whitemap");
         }
     }
 

--- a/Army/ArmyNulgath/ArmyTaintedGem.cs
+++ b/Army/ArmyNulgath/ArmyTaintedGem.cs
@@ -71,7 +71,7 @@ public class ArmyTaintedGem
             Bot.Wait.ForPickup("Tained Gem");
         }
         Core.CancelRegisteredQuests();
-        //Army.waitForParty("whitemap", "Tainted Gem");
+        Army.waitForParty("whitemap", "Tainted Gem");
 
     }
 
@@ -90,7 +90,7 @@ public class ArmyTaintedGem
 
         Core.JumpWait();
         Core.Sleep(2000);
-        //Army.waitForParty("boxes", "Cubes");
+        Army.waitForParty("boxes", "Cubes");
     }
 
     public void IceCube()
@@ -108,6 +108,6 @@ public class ArmyTaintedGem
 
         Core.JumpWait();
         Core.Sleep(2000);
-        //Army.waitForParty("mountfrost", "Ice Cubes");
+        Army.waitForParty("mountfrost", "Ice Cubes");
     }
 }

--- a/Army/ArmyNulgath/ArmyVoucherItemofNulgath.cs
+++ b/Army/ArmyNulgath/ArmyVoucherItemofNulgath.cs
@@ -114,7 +114,7 @@ public class ArmyVoucherItemofNulgath
         Core.EquipClass(ClassType.Farm);
         Core.FarmingLogger(item, quant);
 
-        //Army.waitForParty("tercessuinotlim", item);
+        Army.waitForParty("tercessuinotlim", item);
 
         Army.AggroMonMIDs(2, 3, 4, 5);
         Army.AggroMonStart("tercessuinotlim");

--- a/Army/ArmySeasonal/ArmyHigure.cs
+++ b/Army/ArmySeasonal/ArmyHigure.cs
@@ -102,7 +102,7 @@ public class FarmHigure
             Core.FarmingLogger(item, quant);
             HandleItem(item);
             // After obtaining the item, you can call waitForParty again to butler them separately
-            //Army.waitForParty("whitemap", item, quant);
+            Army.waitForParty("whitemap", item, quant);
         }
 
         // Ensure items are in inventory and buy the sword
@@ -335,7 +335,7 @@ public class FarmHigure
     //         if (Core.CheckInventory(item, remainingQuantity))
     //         {
     //             // Skip to the next case if you already have enough of this item
-    //             //Army.waitForParty("whitemap", item);
+    //             Army.waitForParty("whitemap", item);
     //             continue;
     //         }
 

--- a/Army/ArmySeasonal/ArmyPoly.cs
+++ b/Army/ArmySeasonal/ArmyPoly.cs
@@ -83,7 +83,7 @@ public class ArmyPoly
             Core.CancelRegisteredQuests();
 
             // Wait for the party
-            //Army.waitForParty(map, item);
+            Army.waitForParty(map, item);
         }
     }
 
@@ -116,7 +116,7 @@ public class ArmyPoly
             Core.CancelRegisteredQuests();
 
             // Wait for the party
-            //Army.waitForParty(map, item);
+            Army.waitForParty(map, item);
         }
 
         // Clean up

--- a/Army/Classes/ArmyVoidHighlord.cs
+++ b/Army/Classes/ArmyVoidHighlord.cs
@@ -111,28 +111,28 @@ public class VHLArmy
         {
             PreReqs();
             VHL.VHLChallenge(10);
-            // //Army.waitForParty("whitemap", "Roentgenium of Nulgath");
+            // Army.waitForParty("whitemap", "Roentgenium of Nulgath");
             // Core.SendPackets($"%xt%zm%house%1%{Bot.Player.Username}%");
         }
 
         //======================Last 700 Tainted Gems====================
         Escherion("Tainted Gem", 700 - (100 * Bot.Inventory.GetQuantity("Roentgenium of Nulgath")));
-        // //Army.waitForParty("whitemap", "Tainted Gem");
+        // Army.waitForParty("whitemap", "Tainted Gem");
         // Core.SendPackets($"%xt%zm%house%1%{Bot.Player.Username}%");
 
         //=======================Last 2 Uni 13===========================
         Larvae("Unidentified 13", 15 - Bot.Inventory.GetQuantity("Roentgenium of Nulgath"));
-        // //Army.waitForParty("whitemap", "Unidentified 13");
+        // Army.waitForParty("whitemap", "Unidentified 13");
         // Core.SendPackets($"%xt%zm%house%1%{Bot.Player.Username}%");
 
         //=============DCS check in case somehow not enough==============
         DCSCheck();
-        // //Army.waitForParty("whitemap", "Dark Crystal Shard");
+        // Army.waitForParty("whitemap", "Dark Crystal Shard");
         // Core.SendPackets($"%xt%zm%house%1%{Bot.Player.Username}%");
 
         //========================Blood Gems============================
         BloodGems(30);
-        // //Army.waitForParty("whitemap", "Blood Gem");
+        // Army.waitForParty("whitemap", "Blood Gem");
         // Core.SendPackets($"%xt%zm%house%1%{Bot.Player.Username}%");
 
         //Check for elder blood here in case previous part of the farm
@@ -140,7 +140,7 @@ public class VHLArmy
         ElderBloodChecking();
 
         //========================Last 5 Roents========================
-        // //Army.waitForParty("whitemap", "Roentgenium of Nulgath");
+        // Army.waitForParty("whitemap", "Roentgenium of Nulgath");
         // Core.SendPackets($"%xt%zm%house%1%{Bot.Player.Username}%");
         VHL.VHLChallenge(15);
 
@@ -190,32 +190,32 @@ public class VHLArmy
         ArchfiendsFavorAndNulgathsApproval(4500);
         foreach (string reward in new[] { "Archfiends Favor", "Nulgaths Approval" })
         {
-            // //Army.waitForParty("whitemap", reward);
+            // Army.waitForParty("whitemap", reward);
             // Core.SendPackets($"%xt%zm%house%1%{Bot.Player.Username}%");
         }
 
         Emblems(quantity: 300);
-        // //Army.waitForParty("whitemap", "Emblem of Nulgath");
+        // Army.waitForParty("whitemap", "Emblem of Nulgath");
         // Core.SendPackets($"%xt%zm%house%1%{Bot.Player.Username}%");
 
         Larvae("Unidentified 13", 15 - Bot.Inventory.GetQuantity("Roentgenium of Nulgath"));
-        // //Army.waitForParty("whitemap", "Unidentified 13");
+        // Army.waitForParty("whitemap", "Unidentified 13");
         // Core.SendPackets($"%xt%zm%house%1%{Bot.Player.Username}%");
 
         FarmGemsofNulgath(quant: 450);
-        // //Army.waitForParty("whitemap", "Gem of Nulgath");
+        // Army.waitForParty("whitemap", "Gem of Nulgath");
         // Core.SendPackets($"%xt%zm%house%1%{Bot.Player.Username}%");
 
         FarmTotemsOfNulgath(quant: 15);
-        // //Army.waitForParty("whitemap", "Totem of Nulgath");
+        // Army.waitForParty("whitemap", "Totem of Nulgath");
         // Core.SendPackets($"%xt%zm%house%1%{Bot.Player.Username}%");
 
         Escherion("Tainted Gem", 1000 - (100 * Bot.Inventory.GetQuantity("Roentgenium of Nulgath")));
-        // //Army.waitForParty("whitemap", "Tainted Gem");
+        // Army.waitForParty("whitemap", "Tainted Gem");
         // Core.SendPackets($"%xt%zm%house%1%{Bot.Player.Username}%");
 
         Escherion("Voucher of Nulgath (non-mem)", 1);
-        // //Army.waitForParty("whitemap", "Voucher of Nulgath (non-mem)");
+        // Army.waitForParty("whitemap", "Voucher of Nulgath (non-mem)");
         // Core.SendPackets($"%xt%zm%house%1%{Bot.Player.Username}%");
 
         /* Farm lvl 80 and get minimum gold required to 
@@ -257,7 +257,7 @@ public class VHLArmy
             {
                 Core.JumpWait();
                 Core.SendPackets($"%xt%zm%house%1%{Bot.Player.Username}%");
-                //Army.waitForParty("evilwarnul", reward);
+                Army.waitForParty("evilwarnul", reward);
             }
 
             Core.Logger($"\"Archfiend's Favor\", x{ArchfiendsFavorQuan}, obtained");
@@ -302,7 +302,7 @@ public class VHLArmy
 
         if (Core.CheckInventory(item, quantity))
         {
-            //Army.waitForParty("shadowblast", item);
+            Army.waitForParty("shadowblast", item);
             Core.Logger($"{item}, x{quantity}, obtained");
             return;
         }
@@ -339,7 +339,7 @@ public class VHLArmy
 
         if (Core.CheckInventory(item, quant))
         {
-            //Army.waitForParty("tercessuinotlim", item);
+            Army.waitForParty("tercessuinotlim", item);
             Core.Logger($"{item}, x{quant}, obtained");
             return;
         }
@@ -375,7 +375,7 @@ public class VHLArmy
 
         if (Core.CheckInventory(item, quant))
         {
-            //Army.waitForParty("tercessuinotlim", item);
+            Army.waitForParty("tercessuinotlim", item);
             Core.Logger($"{item}, x{quant}, obtained");
             return;
         }
@@ -403,7 +403,7 @@ public class VHLArmy
 
         if (Core.CheckInventory(item, quant))
         {
-            //Army.waitForParty("tercessuinotlim", item);
+            Army.waitForParty("tercessuinotlim", item);
             Core.Logger($"{item}, x{quant}, obtained");
             return;
         }
@@ -471,7 +471,7 @@ public class VHLArmy
 
         if (Core.CheckInventory("Blood Gem of the Archfiend", quantity))
         {
-            //Army.waitForParty("tercessuinotlim", "Blood Gem of the Archfiend");
+            Army.waitForParty("tercessuinotlim", "Blood Gem of the Archfiend");
             Core.Logger($"\"Blood Gem of the Archfiend\", x{quantity}, obtained");
             return;
         }
@@ -495,7 +495,7 @@ public class VHLArmy
 
         if (Core.CheckInventory(item, quant))
         {
-            //Army.waitForParty("escherion", item);
+            Army.waitForParty("escherion", item);
             Core.Logger($"{item}, x{quant}, obtained");
             return;
         }
@@ -526,7 +526,7 @@ public class VHLArmy
 
         if (Core.CheckInventory(item, quant))
         {
-            //Army.waitForParty("elemental", item);
+            Army.waitForParty("elemental", item);
             Core.Logger($"{item}, x{quant}, obtained");
             return;
         }

--- a/Army/Classes/DragonofTimeArmy.cs
+++ b/Army/Classes/DragonofTimeArmy.cs
@@ -259,7 +259,7 @@ public class DoTArmy
     {
         if (Core.CheckInventory(QuestRewards[0..2], toInv: false))
             foreach (string reward in QuestRewards[0..2])
-                //Army.waitForParty("whitemap", reward);
+                Army.waitForParty("whitemap", reward);
 
                 while (!Bot.ShouldExit && !Core.CheckInventory(QuestRewards[0..2], toInv: false))
                 {
@@ -289,7 +289,7 @@ public class DoTArmy
     {
         if (Core.CheckInventory(QuestRewards[3..5], toInv: false))
             foreach (string reward in QuestRewards[3..5])
-                //Army.waitForParty("whitemap", reward);
+                Army.waitForParty("whitemap", reward);
 
 
                 while (!Bot.ShouldExit && !Core.CheckInventory(QuestRewards[3..5], toInv: false))
@@ -319,7 +319,7 @@ public class DoTArmy
     {
         if (Core.CheckInventory(QuestRewards[6..7], toInv: false))
             foreach (string reward in QuestRewards[6..7])
-                //Army.waitForParty("whitemap", reward);
+                Army.waitForParty("whitemap", reward);
 
 
                 while (!Bot.ShouldExit && !Core.CheckInventory(QuestRewards[6..7], toInv: false))
@@ -349,7 +349,7 @@ public class DoTArmy
     {
         if (Core.CheckInventory(QuestRewards[7..8], toInv: false))
             foreach (string reward in QuestRewards[7..8])
-                //Army.waitForParty("whitemap", reward);
+                Army.waitForParty("whitemap", reward);
 
 
                 while (!Bot.ShouldExit && !Core.CheckInventory(QuestRewards[7..8], toInv: false))
@@ -378,7 +378,7 @@ public class DoTArmy
     {
         if (Core.CheckInventory(QuestRewards[9..10], toInv: false))
             foreach (string reward in QuestRewards[9..10])
-                //Army.waitForParty("whitemap", reward);
+                Army.waitForParty("whitemap", reward);
 
 
                 while (!Bot.ShouldExit && !Core.CheckInventory(QuestRewards[9..10], toInv: false))
@@ -400,7 +400,7 @@ public class DoTArmy
     {
         if (Core.CheckInventory(QuestRewards[11..12], toInv: false))
             foreach (string reward in QuestRewards[11..12])
-                //Army.waitForParty("whitemap", reward);
+                Army.waitForParty("whitemap", reward);
 
 
                 while (!Bot.ShouldExit && !Core.CheckInventory(QuestRewards[11..12], toInv: false))
@@ -445,7 +445,7 @@ public class DoTArmy
     {
         if (Core.CheckInventory(QuestRewards[13..14], toInv: false))
             foreach (string reward in QuestRewards[13..14])
-                //Army.waitForParty("whitemap", reward);
+                Army.waitForParty("whitemap", reward);
 
 
                 while (!Bot.ShouldExit && !Core.CheckInventory(QuestRewards[13..14], toInv: false))
@@ -475,7 +475,7 @@ public class DoTArmy
     {
         if (Core.CheckInventory(QuestRewards[14..15], toInv: false))
             foreach (string reward in QuestRewards[14..15])
-                //Army.waitForParty("whitemap", reward);
+                Army.waitForParty("whitemap", reward);
 
                 while (!Bot.ShouldExit && !Core.CheckInventory(QuestRewards[14..15], toInv: false))
                 {
@@ -500,7 +500,7 @@ public class DoTArmy
     {
         if (Core.CheckInventory(QuestRewards[16..19], toInv: false))
             foreach (string reward in QuestRewards[16..19])
-                //Army.waitForParty("whitemap", reward);
+                Army.waitForParty("whitemap", reward);
 
 
                 while (!Bot.ShouldExit && !Core.CheckInventory(QuestRewards[16..19], toInv: false))
@@ -524,9 +524,9 @@ public class DoTArmy
 
     public void DoQuest10()
     {
-    //     if (Core.CheckInventory(QuestRewards[20..21], toInv: false))
-    //         foreach (string reward in QuestRewards[20..21])
-    //             Army.waitForParty("whitemap", reward);
+        if (Core.CheckInventory(QuestRewards[20..21], toInv: false))
+            foreach (string reward in QuestRewards[20..21])
+                Army.waitForParty("whitemap", reward);
 
         // else
          Core.Logger("Quest already complete / Items owned, butlering[hopefully]");
@@ -612,7 +612,7 @@ public class DoTArmy
             Army.SellToSync(item, quant);
 
         Core.AddDrop(item);
-        //Army.waitForParty(map);
+        Army.waitForParty(map);
 
         Core.EquipClass(classType);
         Core.FarmingLogger(item, quant);
@@ -655,7 +655,7 @@ public class DoTArmy
             Core.JumpWait();
             Core.Sleep(2500);
         }
-        //Army.waitForParty(map, item);
+        Army.waitForParty(map, item);
     }
 
     void ArmyHunt(string map, int monsterID, string item, ClassType classType, bool isTemp = false, int quant = 1)
@@ -674,7 +674,7 @@ public class DoTArmy
             Army.SellToSync(item, quant);
 
         Core.AddDrop(item);
-        //Army.waitForParty(map);
+        Army.waitForParty(map);
 
         Core.EquipClass(classType);
         Core.FarmingLogger(item, quant);
@@ -694,7 +694,7 @@ public class DoTArmy
             Core.JumpWait();
             Core.Sleep(2500);
         }
-        //Army.waitForParty(map, item);
+        Army.waitForParty(map, item);
     }
 
 

--- a/Army/CoreArmyLite.cs
+++ b/Army/CoreArmyLite.cs
@@ -809,21 +809,28 @@ public class CoreArmyLite
                 while (!Bot.ShouldExit && (Bot.Player.HasTarget || Bot.Player.InCombat))
                 {
                     Bot.Options.AttackWithoutTarget = false;
+                    Bot.Combat.Exit();
                     Bot.Combat.CancelTarget();
-                    Core.Sleep();
                     Core.JumpWait();
                 }
+                
 
                 // Do these things if that fails
                 string stopLocation = Core.CustomStopLocation?.Trim().ToLower() ?? string.Empty;
-                if (!string.IsNullOrWhiteSpace(stopLocation))
-                    Core.Join(stopLocation, "Enter", "Spawn", false, false);
-                else Core.Join("whitemap");
+                if (!string.IsNullOrWhiteSpace(stopLocation)) {
+                    Core.Logger(stopLocation);
+                    if (stopLocation.Equals("home") || stopLocation.Equals("house"))
+                        Bot.Send.Packet($"%xt%zm%house%1%{Core.Username()}%");
+                    else 
+                        Core.Join(stopLocation, "Enter", "Spawn", false, false);
+                } else 
+                    Core.Join("whitemap");
+                
 
                 Core.Logger($"Could not find {playerName}. Check if \"{playerName}\" is in the same server with you.", "tryGoto");
                 if (b_shouldHibernate)
                     Core.Logger($"The bot will now hibernate and try to /goto to {playerName} every {hibernateTimer} seconds.", "tryGoto");
-
+                
                 int min = 1;
                 while (!Bot.ShouldExit)
                 {

--- a/Army/CoreArmyLite.cs
+++ b/Army/CoreArmyLite.cs
@@ -818,7 +818,6 @@ public class CoreArmyLite
                 // Do these things if that fails
                 string stopLocation = Core.CustomStopLocation?.Trim().ToLower() ?? string.Empty;
                 if (!string.IsNullOrWhiteSpace(stopLocation)) {
-                    Core.Logger(stopLocation);
                     if (stopLocation.Equals("home") || stopLocation.Equals("house"))
                         Bot.Send.Packet($"%xt%zm%house%1%{Core.Username()}%");
                     else 

--- a/Army/CoreArmyLite.cs
+++ b/Army/CoreArmyLite.cs
@@ -431,11 +431,8 @@ public class CoreArmyLite
                 ResetServer();
                 throw;
             }
-            
-            Bot.Events.ScriptStopping += exception => { 
-                ResetServer();
-                return true;
-            };
+
+            Bot.Events.ScriptStopping += ResetServerBool;
             Bot.Events.Logout += ResetServer;
         } else { // Start client
             try {
@@ -447,11 +444,8 @@ public class CoreArmyLite
                 ResetClient();
                 throw;
             }
-            
-            Bot.Events.ScriptStopping += exception => { 
-                ResetClient();
-                return true;
-            };
+
+            Bot.Events.ScriptStopping += ResetClientBool;
             Bot.Events.Logout += ResetClient;
         }
 
@@ -506,11 +500,23 @@ public class CoreArmyLite
         void ResetServer() {
             fileStream?.Close();
             communication?.Stop();
-            
+
+            Bot.Events.ScriptStopping -= ResetServerBool;
+            Bot.Events.Logout -= ResetServer;
+        }
+        bool ResetServerBool(Exception? e) {
+            ResetServer();
+            return true;
         }
         void ResetClient() {
             communication?.Stop();
-            
+
+            Bot.Events.ScriptStopping -= ResetClientBool;
+            Bot.Events.Logout -= ResetClient;
+        }
+        bool ResetClientBool(Exception? e) {
+            ResetClient();
+            return true;
         }
 
         void PlayerAFK()

--- a/Army/CoreArmyLite.cs
+++ b/Army/CoreArmyLite.cs
@@ -814,12 +814,15 @@ public class CoreArmyLite
             // Try to go to the followed player
             if (!tryGoto(playerName))
             {
-                while (!Bot.ShouldExit && (Bot.Player.HasTarget || Bot.Player.InCombat))
+                int repeats = 0; //Repeats is so that it doesn't get stuck forever
+                while (!Bot.ShouldExit && ((Bot.Player.HasTarget || Bot.Player.InCombat) && repeats < 5)) 
                 {
-                    Bot.Options.AttackWithoutTarget = false;
-                    Bot.Combat.Exit();
+                    Bot.Combat.CancelAutoAttack();
                     Bot.Combat.CancelTarget();
-                    Core.JumpWait();
+                    Bot.Map.Jump(Bot.Player.Cell, Bot.Player.Pad);
+                    Thread.Sleep(300);
+                    Bot.Map.Jump(Bot.Player.Cell, Bot.Player.Pad);
+                    repeats++;
                 }
                 
 

--- a/Army/CoreArmyLite.cs
+++ b/Army/CoreArmyLite.cs
@@ -494,8 +494,10 @@ public class CoreArmyLite
             Core.Logger($"Party complete [{partySize}/{partySize}]");
         Core.Sleep(3500); //To make sure everyone attack at the same time, to avoid deaths
         
-        communication.Stop();
-        fileStream?.Close(); //Releases the file
+        if (communication is PipeServer)
+            ResetServer();
+        else 
+            ResetClient();
 
         void ResetServer() {
             fileStream?.Close();

--- a/Army/CoreArmyLite.cs
+++ b/Army/CoreArmyLite.cs
@@ -399,14 +399,14 @@ public class CoreArmyLite
         return players.ToArray();
     }
 
-    public void waitForParty(string map, string caller, string? item = null, int playerMax = -1)
+    public void waitForParty(string map, string? item = null, int playerMax = -1, string? callerClass = "", [CallerMemberName] string? caller = "")
     {
         Bot.Events.PlayerAFK += PlayerAFK;
         string[] players = Players();
         int partySize = players.Length;
         List<string> playersWhoHaveBeenHere = new() { Bot.Player.Username };
         int playerCount = 1;
-        FileInfo waitFile = new FileInfo(Path.Combine(CoreBots.ButlerLogDir, $"{caller}.txt"));
+        FileInfo waitFile = new FileInfo(Path.Combine(CoreBots.ButlerLogDir, $"{(callerClass == "" ? caller : callerClass)}.txt"));
 
         FileStream fileStream = null;
         int logCount = 0;
@@ -539,6 +539,7 @@ public class CoreArmyLite
         void ServerMessageReceived(object? o, MessageReceivedEventArgs messageReceivedEventArgs) {
             var server = (PipeServer) o;
             var message = messageReceivedEventArgs.Message;
+            Core.Logger(message);
             if (message.Contains("Connected:")) {
                 var name = message.Replace("Connected:", "");
                 if (!playersWhoHaveBeenHere.Contains(name) && 
@@ -557,6 +558,7 @@ public class CoreArmyLite
         void ClientMessageReceived(object? o, MessageReceivedEventArgs messageReceivedEventArgs) {
             var client = (PipeClient) o;
             var message = messageReceivedEventArgs.Message;
+            Core.Logger(message);
             if (message.Contains("Start")) {
                 shouldStart = true;
             }

--- a/Army/CoreArmyLite.cs
+++ b/Army/CoreArmyLite.cs
@@ -820,7 +820,7 @@ public class CoreArmyLite
                     Bot.Combat.CancelAutoAttack();
                     Bot.Combat.CancelTarget();
                     Bot.Map.Jump(Bot.Player.Cell, Bot.Player.Pad);
-                    Thread.Sleep(300);
+                    Core.Sleep(300);
                     Bot.Map.Jump(Bot.Player.Cell, Bot.Player.Pad);
                     repeats++;
                 }

--- a/Army/Quests/ArmyNSODDaily.cs
+++ b/Army/Quests/ArmyNSODDaily.cs
@@ -59,7 +59,7 @@ public class ArmyNSoDDaily
         Core.EquipClass(ClassType.Solo);
         Core.EnsureAccept(8653);
 
-        //Army.waitForParty("Icestormarena", "Glacial Pinion");
+        Army.waitForParty("Icestormarena", "Glacial Pinion");
         Army.SmartAggroMonStart("icewing", "Warlord Icewing");
 
         
@@ -69,7 +69,7 @@ public class ArmyNSoDDaily
         Army.AggroMonStop();
         Core.JumpWait();
 
-        //Army.waitForParty("hydrachallenge", "Hydra Eyeball");
+        Army.waitForParty("hydrachallenge", "Hydra Eyeball");
         Army.SmartAggroMonStart("hydrachallenge", "Hydra Head 90");
 
         
@@ -79,7 +79,7 @@ public class ArmyNSoDDaily
         Army.AggroMonStop();
         Core.JumpWait();
 
-        //Army.waitForParty("voidflibbi", "Flibbitigiblets");
+        Army.waitForParty("voidflibbi", "Flibbitigiblets");
         Army.SmartAggroMonStart("voidflibbi", "Flibbitiestgibbet");
 
         

--- a/Army/Various/ArmyArchMageBossItems.cs
+++ b/Army/Various/ArmyArchMageBossItems.cs
@@ -107,7 +107,7 @@ public class ArchMageMatsArmy
         else
         {
             Core.Logger($"{item} Found.");
-            //Army.waitForParty(map, item);
+            Army.waitForParty(map, item);
         }
 
         if (Bot.Map.Name == "darkcarnax")

--- a/Army/Various/ArmyDarkonErrands.cs
+++ b/Army/Various/ArmyDarkonErrands.cs
@@ -87,7 +87,7 @@ public class ArmyDarkonErrands
         Core.AddDrop(item);
         Core.EquipClass(classType);
 
-        //Army.waitForParty(map, item);
+        Army.waitForParty(map, item);
         Core.FarmingLogger(item, quant);
 
         switch (Method)

--- a/Army/Various/ArmyLightCasterFull.cs
+++ b/Army/Various/ArmyLightCasterFull.cs
@@ -105,7 +105,7 @@ public class ArmyLightCaster
         Core.AddDrop(item);
 
         Core.EquipClass(classType);
-        //Army.waitForParty(map, item);
+        Army.waitForParty(map, item);
         Core.FarmingLogger(item, quant);
 
         Army.SmartAggroMonStart(map, monsters);

--- a/Army/Various/ArmyPennyForYourThoughts.cs
+++ b/Army/Various/ArmyPennyForYourThoughts.cs
@@ -69,7 +69,7 @@ public class ArmyPennyForYourThoughts
 
         while (!Bot.ShouldExit && !Core.CheckInventory("Dark Spirit Orb", 10500))
             Bot.Combat.Attack("*");
-        //Army.waitForParty("whitemap", "Dark Spirit Orb");
+        Army.waitForParty("whitemap", "Dark Spirit Orb");
         Army.AggroMonStop(true);
         Core.CancelRegisteredQuests();
     }

--- a/Army/Various/ArmyPrismaticSeams.cs
+++ b/Army/Various/ArmyPrismaticSeams.cs
@@ -70,7 +70,7 @@ public class ArmyPrimaticSeams
         while (!Bot.ShouldExit && !Core.CheckInventory("Prismatic Seams", 2000))
             Bot.Combat.Attack("*");
 
-        //Army.waitForParty("streamwar", "Prismatic Seams");
+        Army.waitForParty("streamwar", "Prismatic Seams");
         Army.AggroMonStop(true);
         Core.CancelRegisteredQuests();
     }

--- a/Army/Various/ArmySmartVoidAuas.cs
+++ b/Army/Various/ArmySmartVoidAuas.cs
@@ -141,7 +141,7 @@ public class ArmySmartVoidAuras
         Core.AddDrop(item);
 
         Core.EquipClass(classType);
-        //Army.waitForParty(map, item);
+        Army.waitForParty(map, item);
         Core.FarmingLogger(item, quant);
 
         Army.SmartAggroMonStart(map, monsters);


### PR DESCRIPTION
# WIP

Add waitForParty synchronization with custom implementation of C# pipes
Also fixes butler getting stuck on exiting combat, and failing to enter house

## How to test:
1. Add `System.IO.Pipes.dll` to the Skua plugins directory. This dll can be found with your installation of .Net or on [NuGet](https://www.nuget.org/packages/System.IO.Pipes/)
2. Add `ClientServerUsingNamedPipes.dll` to the Skua plugins directory. This dll can be found [on my GitHub repo](https://github.com/robmart/ClientServerUsingNamedPipes/actions)
3. Add a `ClientServerUsingNamedPipes.dll` reference to your Scripts project
3. Use waitForParty like normal

## Info
* The Skua plugins directory is at `Documents\Skua\plugins`
* Pipes is a way for C# apps to communicate with one another. As pipes can only have one client per server (wtf is up with that MS,) a custom implementation of pipes had to be created to allow multiple server/client pairs easily.
* Pipes only work locally, the script will only work when run on the same PC.
* It designates one client as the "server." This server manages all who is connected and decides when the script/butler should start.
* The first instance to start waiting becomes the server.
