### PR TITLE
feat(CoreAdvanced): change TimeKeeper and TimeKiller smart enhancemen…

### DIFF
--- a/CoreAdvanced.cs
+++ b/CoreAdvanced.cs
@@ -2825,11 +2825,22 @@ public class CoreAdvanced
                     break;
                 #endregion Lucky - Dauntless - Vim - Penitence
 
+                #region Lucky - Lacerate - Vim - Lament
+                case "timekeeper":
+                case "timekiller":
+                    if (!uLacerate() || !uVim() || !uLament())
+                        goto default;
+
+                    type = EnhancementType.Lucky;
+                    cSpecial = CapeSpecial.Lament;
+                    wSpecial = WeaponSpecial.Lacerate;
+                    hSpecial = HelmSpecial.Vim;
+                    break;
+                #endregion Lucky - Lacerate - Vim - Lament
+
                 #region Lucky - Forge - Spiral Carve
                 case "corrupted chronomancer":
                 case "underworld chronomancer":
-                case "timekeeper":
-                case "timekiller":
                 case "eternal chronomancer":
                 case "immortal chronomancer":
                 case "dark metal necro":


### PR DESCRIPTION
…ts for using optimal 100% dodge rate

I would assume that the optimal enhancements for these classes, at least when botting would always be the ones needed for achieving 100% dodge rate. This ensures their capability for soloing a lot of content consistently.

Took from [this](https://docs.google.com/spreadsheets/d/1wupDvLuPnRC0fF0aNPc7rzrri7X1YcYy7S2s5Z6o_F4/edit?gid=0#gid=0) sheet and tested.